### PR TITLE
Adding cname anonymization

### DIFF
--- a/src/anonymizer.rs
+++ b/src/anonymizer.rs
@@ -45,6 +45,7 @@ pub struct StatefulSdpAnonymizer {
     ice_users: AnonymizationStrMap,
     cert_finger_prints: HashMap<Vec<u8>, Vec<u8>>,
     cert_finger_print_inc: Wrapping<u64>,
+    cnames: AnonymizationStrMap,
 }
 
 impl Default for StatefulSdpAnonymizer {
@@ -67,6 +68,7 @@ impl StatefulSdpAnonymizer {
             ice_users: AnonymizationStrMap::new("ice-user-", 8),
             cert_finger_prints: HashMap::new(),
             cert_finger_print_inc: Wrapping(0),
+            cnames: AnonymizationStrMap::new("cname-", 8),
         }
     }
 
@@ -146,6 +148,10 @@ impl StatefulSdpAnonymizer {
             self.cert_finger_print_inc.0.to_byte_vec(),
         );
         self.cert_finger_print_inc.0.to_byte_vec()
+    }
+
+    pub fn mask_cname(&mut self, cname: &str) -> String {
+        self.cnames.mask(cname)
     }
 }
 
@@ -288,6 +294,18 @@ mod tests {
             assert_eq!(anon.mask_cert_finger_print(&prints[0]), masked_prints[0]);
             assert_eq!(anon.mask_cert_finger_print(&prints[1]), masked_prints[1]);
             assert_eq!(anon.mask_cert_finger_print(&prints[2]), masked_prints[2]);
+        }
+    }
+
+    #[test]
+    fn test_mask_cname() {
+        let mut anon = StatefulSdpAnonymizer::default();
+        let cnames = ["mailto:foo@bar", "JohnDoe", "Jane Doe"];
+        let masked_cnames = ["cname-00000001", "cname-00000002", "cname-00000003"];
+        for _ in 0..2 {
+            assert_eq!(anon.mask_cname(cnames[0]), masked_cnames[0]);
+            assert_eq!(anon.mask_cname(cnames[1]), masked_cnames[1]);
+            assert_eq!(anon.mask_cname(cnames[2]), masked_cnames[2]);
         }
     }
 }

--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -3807,16 +3807,21 @@ mod tests {
     #[test]
     fn test_anonymize_attribute_ssrc() -> Result<(), SdpParserInternalError> {
         let mut anon = StatefulSdpAnonymizer::new();
-        let ssrc1 =
+        let parsed =
             parse_attribute("ssrc:2655508255 cname:{735484ea-4f6c-f74a-bd66-7425f8476c2e}")?;
-        if let SdpType::Attribute(SdpAttribute::Ssrc(ssrc1)) = ssrc1 {
-            let masked = ssrc1.masked_clone(&mut anon);
-            assert_eq!(ssrc1.id, masked.id);
-            assert_eq!(ssrc1.attribute, masked.attribute);
-            assert_eq!("cname-00000001", masked.value.unwrap());
+        let (ssrc1, masked) = if let SdpType::Attribute(a) = parsed {
+            let masked = a.masked_clone(&mut anon);
+            match (a, masked) {
+                (SdpAttribute::Ssrc(ssrc), SdpAttribute::Ssrc(masked)) => (ssrc, masked),
+                (_, _) => unreachable!(),
+            }
         } else {
             unreachable!()
-        }
+        };
+        assert_eq!(ssrc1.id, masked.id);
+        assert_eq!(ssrc1.attribute, masked.attribute);
+        assert_eq!("cname-00000001", masked.value.unwrap());
+
         let ssrc2 = parse_attribute("ssrc:2082260239 msid:1d0cdb4e-5934-4f0f-9f88-40392cb60d31 315b086a-5cb6-4221-89de-caf0b038c79d")?;
         if let SdpType::Attribute(SdpAttribute::Ssrc(ssrc2)) = ssrc2 {
             let masked = ssrc2.masked_clone(&mut anon);

--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -1068,6 +1068,22 @@ impl fmt::Display for SdpAttributeSsrc {
     }
 }
 
+impl AnonymizingClone for SdpAttributeSsrc {
+    fn masked_clone(&self, anon: &mut StatefulSdpAnonymizer) -> Self {
+        Self {
+            id: self.id,
+            attribute: self.attribute.clone(),
+            value: self.attribute.as_ref().and_then(|attribute| {
+                match (attribute.to_lowercase().as_str(), &self.value) {
+                    ("cname", Some(ref cname)) => Some(anon.mask_cname(cname.as_str())),
+                    (_, Some(_)) => self.value.clone(),
+                    (_, None) => None,
+                }
+            }),
+        }
+    }
+}
+
 #[derive(Clone)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 pub enum SdpAttribute {
@@ -1331,6 +1347,7 @@ impl AnonymizingClone for SdpAttribute {
             SdpAttribute::IcePwd(i) => SdpAttribute::IcePwd(anon.mask_ice_password(i)),
             SdpAttribute::IceUfrag(i) => SdpAttribute::IceUfrag(anon.mask_ice_user(i)),
             SdpAttribute::RemoteCandidate(i) => SdpAttribute::RemoteCandidate(i.masked_clone(anon)),
+            SdpAttribute::Ssrc(i) => SdpAttribute::Ssrc(i.masked_clone(anon)),
             _ => self.clone(),
         }
     }
@@ -3785,6 +3802,31 @@ mod tests {
 
         assert!(parse_attribute("ssrc:").is_err());
         assert!(parse_attribute("ssrc:foo").is_err());
+    }
+
+    #[test]
+    fn test_anonymize_attribute_ssrc() -> Result<(), SdpParserInternalError> {
+        let mut anon = StatefulSdpAnonymizer::new();
+        let ssrc1 =
+            parse_attribute("ssrc:2655508255 cname:{735484ea-4f6c-f74a-bd66-7425f8476c2e}")?;
+        if let SdpType::Attribute(SdpAttribute::Ssrc(ssrc1)) = ssrc1 {
+            let masked = ssrc1.masked_clone(&mut anon);
+            assert_eq!(ssrc1.id, masked.id);
+            assert_eq!(ssrc1.attribute, masked.attribute);
+            assert_eq!("cname-00000001", masked.value.unwrap());
+        } else {
+            unreachable!()
+        }
+        let ssrc2 = parse_attribute("ssrc:2082260239 msid:1d0cdb4e-5934-4f0f-9f88-40392cb60d31 315b086a-5cb6-4221-89de-caf0b038c79d")?;
+        if let SdpType::Attribute(SdpAttribute::Ssrc(ssrc2)) = ssrc2 {
+            let masked = ssrc2.masked_clone(&mut anon);
+            assert_eq!(ssrc2.id, masked.id);
+            assert_eq!(ssrc2.attribute, masked.attribute);
+            assert_eq!(ssrc2.value, masked.value);
+        } else {
+            unreachable!()
+        }
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
This patch prevents revealing information from sneaking past annonymization via the cname blob.