### PR TITLE
Remove the dependency on enum-display-derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,3 @@ url = {version="1.7.2"}
 
 [dev-dependencies]
 serde_json = {version = "1.0"}
-enum-display-derive = {version = "0.1.0"}

--- a/src/address.rs
+++ b/src/address.rs
@@ -195,13 +195,20 @@ mod tests {
     use self::url::ParseError;
     use super::*;
     use std::error::Error;
-    use std::fmt::Display;
     use std::net::{AddrParseError, Ipv4Addr, Ipv6Addr};
 
-    #[derive(Debug, enum_display_derive::Display)]
+    #[derive(Debug)]
     enum ParseTestError {
         Host(ParseError),
         Ip(AddrParseError),
+    }
+    impl fmt::Display for ParseTestError {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match self {
+                ParseTestError::Host(inner) => inner.fmt(f),
+                ParseTestError::Ip(inner) => inner.fmt(f),
+            }
+        }
     }
     impl From<ParseError> for ParseTestError {
         fn from(err: ParseError) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@ extern crate log;
 #[cfg(feature = "serialize")]
 #[macro_use]
 extern crate serde_derive;
-#[cfg(test)]
-extern crate enum_display_derive;
 #[cfg(feature = "serialize")]
 extern crate serde;
 use std::convert::TryFrom;


### PR DESCRIPTION
That's a lot of code to avoid writing one display implementation. Plus
that crate is unmaintained and still depends on syn 0.11 and quote 0.3