### PR TITLE
rtpmap should not add an encoding parameter to video when one is not there

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,7 @@ pub enum SdpType {
 pub struct SdpLine {
     pub line_number: usize,
     pub sdp_type: SdpType,
+    pub text: String,
 }
 
 /*
@@ -621,6 +622,7 @@ fn parse_sdp_line(line: &str, line_number: usize) -> Result<SdpLine, SdpParserEr
     .map(|sdp_type| SdpLine {
         line_number,
         sdp_type,
+        text: line.to_owned(),
     })
     .map_err(|e| match e {
         SdpParserInternalError::UnknownAddressType(..)


### PR DESCRIPTION
Resolves #186