### PR TITLE
Be more permissive while parsing parameter lists

### DIFF
--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -3507,7 +3507,9 @@ mod tests {
         assert!(parse_attribute("fmtp:8 packetization-mode=2;;maxplaybackrate=48000").is_ok());
         assert!(parse_attribute("fmtp:8 packetization-mode=2; maxplaybackrate=48000").is_ok());
         assert!(parse_attribute("fmtp:8 maxplaybackrate=48000;").is_ok());
-        assert!(parse_attribute("fmtp:8 x-google-start-bitrate=800; maxplaybackrate=48000;").is_ok());
+        assert!(
+            parse_attribute("fmtp:8 x-google-start-bitrate=800; maxplaybackrate=48000;").is_ok()
+        );
     }
 
     #[test]

--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -1905,7 +1905,7 @@ fn parse_fmtp(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError> {
         unknown_tokens: Vec::new(),
     };
 
-    for parameter_token in tokens[1..].to_vec() {
+    for parameter_token in tokens[1..].iter() {
         if parameter_token.contains('=') {
             // Permit Leading/Trailing/Inner ';' by filtering out empty splits
             let parameter_tokens: Vec<&str> = parameter_token
@@ -1916,8 +1916,7 @@ fn parse_fmtp(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError> {
                 let name_value_pair: Vec<&str> = parameter_token.splitn(2, '=').collect();
                 if name_value_pair.len() != 2 {
                     return Err(SdpParserInternalError::Generic(
-                        "A fmtp parameter must be either a telephone event, a parameter list or
-                                                                    a red codec list"
+                        "A fmtp parameter must be either a telephone event, a parameter list or a red codec list"
                             .to_string(),
                     ));
                 }

--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -1875,14 +1875,14 @@ fn parse_fingerprint(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalEr
 fn parse_fmtp(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError> {
     let tokens: Vec<&str> = to_parse.splitn(2, ' ').collect();
 
-    if tokens.len() != 2 {
+    // Support space seperated parameter blocks
+    if tokens.len() < 2 {
         return Err(SdpParserInternalError::Unsupported(
             "Fmtp attributes require a payload type and a parameter block.".to_string(),
         ));
     }
 
     let payload_token = tokens[0];
-    let parameter_token = tokens[1];
 
     // Default initiliaze SdpAttributeFmtpParameters
     let mut parameters = SdpAttributeFmtpParameters {
@@ -1905,146 +1905,153 @@ fn parse_fmtp(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError> {
         unknown_tokens: Vec::new(),
     };
 
-    if parameter_token.contains('=') {
-        let parameter_tokens: Vec<&str> = parameter_token.split(';').collect();
-
-        for parameter_token in parameter_tokens.iter() {
-            let name_value_pair: Vec<&str> = parameter_token.splitn(2, '=').collect();
-
-            if name_value_pair.len() != 2 {
-                return Err(SdpParserInternalError::Generic(
-                    "A fmtp parameter must be either a telephone event, a parameter list or
+    for parameter_token in tokens[1..].to_vec() {
+        if parameter_token.contains('=') {
+            // Permit Leading/Trailing/Inner ';' by filtering out empty splits
+            let parameter_tokens: Vec<&str> = parameter_token
+                .split(';')
+                .filter(|token| !token.is_empty())
+                .collect();
+            for parameter_token in parameter_tokens.iter() {
+                let name_value_pair: Vec<&str> = parameter_token.splitn(2, '=').collect();
+                if name_value_pair.len() != 2 {
+                    return Err(SdpParserInternalError::Generic(
+                        "A fmtp parameter must be either a telephone event, a parameter list or
                                                                     a red codec list"
-                        .to_string(),
-                ));
-            }
+                            .to_string(),
+                    ));
+                }
 
-            let parse_bool =
-                |val: &str, param_name: &str| -> Result<bool, SdpParserInternalError> {
-                    match val.parse::<u8>()? {
-                        0 => Ok(false),
-                        1 => Ok(true),
-                        _ => Err(SdpParserInternalError::Generic(format!(
-                            "The fmtp parameter '{:}' must be 0 or 1",
-                            param_name
-                        ))),
-                    }
-                };
+                let parse_bool =
+                    |val: &str, param_name: &str| -> Result<bool, SdpParserInternalError> {
+                        match val.parse::<u8>()? {
+                            0 => Ok(false),
+                            1 => Ok(true),
+                            _ => Err(SdpParserInternalError::Generic(format!(
+                                "The fmtp parameter '{:}' must be 0 or 1",
+                                param_name
+                            ))),
+                        }
+                    };
 
-            let parameter_name = name_value_pair[0];
-            let parameter_val = name_value_pair[1];
+                let parameter_name = name_value_pair[0];
+                let parameter_val = name_value_pair[1];
 
-            match parameter_name.to_uppercase().as_str() {
-                // H264
-                "PROFILE-LEVEL-ID" => {
-                    parameters.profile_level_id = match u32::from_str_radix(parameter_val, 16)? {
+                match parameter_name.to_uppercase().as_str() {
+                    // H264
+                    "PROFILE-LEVEL-ID" => parameters.profile_level_id = match u32::from_str_radix(
+                        parameter_val,
+                        16,
+                    )? {
                         x @ 0..=0x00ff_ffff => x,
                         _ => return Err(SdpParserInternalError::Generic(
                             "The fmtp parameter 'profile-level-id' must be in range [0,0xffffff]"
                                 .to_string(),
                         )),
-                    }
-                }
-                "PACKETIZATION-MODE" => {
-                    parameters.packetization_mode = match parameter_val.parse::<u32>()? {
-                        x @ 0..=2 => x,
-                        _ => {
-                            return Err(SdpParserInternalError::Generic(
-                                "The fmtp parameter 'packetization-mode' must be 0,1 or 2"
-                                    .to_string(),
-                            ));
+                    },
+                    "PACKETIZATION-MODE" => {
+                        parameters.packetization_mode = match parameter_val.parse::<u32>()? {
+                            x @ 0..=2 => x,
+                            _ => {
+                                return Err(SdpParserInternalError::Generic(
+                                    "The fmtp parameter 'packetization-mode' must be 0,1 or 2"
+                                        .to_string(),
+                                ));
+                            }
                         }
                     }
-                }
-                "LEVEL-ASYMMETRY-ALLOWED" => {
-                    parameters.level_asymmetry_allowed =
-                        parse_bool(parameter_val, "level-asymmetry-allowed")?
-                }
-                "MAX-MBPS" => parameters.max_mbps = parameter_val.parse::<u32>()?,
-                "MAX-FS" => parameters.max_fs = parameter_val.parse::<u32>()?,
-                "MAX-CPB" => parameters.max_cpb = parameter_val.parse::<u32>()?,
-                "MAX-DPB" => parameters.max_dpb = parameter_val.parse::<u32>()?,
-                "MAX-BR" => parameters.max_br = parameter_val.parse::<u32>()?,
+                    "LEVEL-ASYMMETRY-ALLOWED" => {
+                        parameters.level_asymmetry_allowed =
+                            parse_bool(parameter_val, "level-asymmetry-allowed")?
+                    }
+                    "MAX-MBPS" => parameters.max_mbps = parameter_val.parse::<u32>()?,
+                    "MAX-FS" => parameters.max_fs = parameter_val.parse::<u32>()?,
+                    "MAX-CPB" => parameters.max_cpb = parameter_val.parse::<u32>()?,
+                    "MAX-DPB" => parameters.max_dpb = parameter_val.parse::<u32>()?,
+                    "MAX-BR" => parameters.max_br = parameter_val.parse::<u32>()?,
 
-                // VP8 and VP9
-                "MAX-FR" => parameters.max_fr = parameter_val.parse::<u32>()?,
+                    // VP8 and VP9
+                    "MAX-FR" => parameters.max_fr = parameter_val.parse::<u32>()?,
 
-                //Opus
-                "MAXPLAYBACKRATE" => parameters.maxplaybackrate = parameter_val.parse::<u32>()?,
-                "USEDTX" => parameters.usedtx = parse_bool(parameter_val, "usedtx")?,
-                "STEREO" => parameters.stereo = parse_bool(parameter_val, "stereo")?,
-                "USEINBANDFEC" => {
-                    parameters.useinbandfec = parse_bool(parameter_val, "useinbandfec")?
-                }
-                "CBR" => parameters.cbr = parse_bool(parameter_val, "cbr")?,
-                _ => parameters.unknown_tokens.push(parameter_token.to_string()),
-            }
-        }
-    } else if parameter_token.contains('/') {
-        let encodings: Vec<&str> = parameter_token.split('/').collect();
-
-        for encoding in encodings {
-            match encoding.parse::<u8>()? {
-                x @ 0..=128 => parameters.encodings.push(x),
-                _ => {
-                    return Err(SdpParserInternalError::Generic(
-                        "Red codec must be in range [0,128]".to_string(),
-                    ));
+                    //Opus
+                    "MAXPLAYBACKRATE" => {
+                        parameters.maxplaybackrate = parameter_val.parse::<u32>()?
+                    }
+                    "USEDTX" => parameters.usedtx = parse_bool(parameter_val, "usedtx")?,
+                    "STEREO" => parameters.stereo = parse_bool(parameter_val, "stereo")?,
+                    "USEINBANDFEC" => {
+                        parameters.useinbandfec = parse_bool(parameter_val, "useinbandfec")?
+                    }
+                    "CBR" => parameters.cbr = parse_bool(parameter_val, "cbr")?,
+                    _ => parameters.unknown_tokens.push(parameter_token.to_string()),
                 }
             }
-        }
-    } else {
-        // This is the case for the 'telephone-event' codec
-        let dtmf_tones: Vec<&str> = parameter_token.split(',').collect();
-        let mut dtmf_tone_is_ok = true;
+        } else if parameter_token.contains('/') {
+            let encodings: Vec<&str> = parameter_token.split('/').collect();
 
-        // This closure verifies the output of some_number_as_string.parse::<u8>().ok() like calls
-        let validate_digits = |digit_option: Option<u8>| -> Option<u8> {
-            match digit_option {
-                Some(x) => match x {
-                    0..=100 => Some(x),
-                    _ => None,
-                },
-                None => None,
-            }
-        };
-
-        // This loop does some sanity checking on the passed dtmf tones
-        for dtmf_tone in dtmf_tones {
-            let dtmf_tone_range: Vec<&str> = dtmf_tone.splitn(2, '-').collect();
-
-            dtmf_tone_is_ok = match dtmf_tone_range.len() {
-                // In this case the dtmf tone is a range
-                2 => {
-                    match validate_digits(dtmf_tone_range[0].parse::<u8>().ok()) {
-                        Some(l) => match validate_digits(dtmf_tone_range[1].parse::<u8>().ok()) {
-                            Some(u) => {
-                                // Check that the first part of the range is smaller than the second part
-                                l < u
-                            }
-                            None => false,
-                        },
-                        None => false,
+            for encoding in encodings {
+                match encoding.parse::<u8>()? {
+                    x @ 0..=128 => parameters.encodings.push(x),
+                    _ => {
+                        return Err(SdpParserInternalError::Generic(
+                            "Red codec must be in range [0,128]".to_string(),
+                        ));
                     }
                 }
-                // In this case the dtmf tone is a single tone
-                1 => validate_digits(dtmf_tone.parse::<u8>().ok()).is_some(),
-                _ => false,
+            }
+        } else {
+            // This is the case for the 'telephone-event' codec
+            let dtmf_tones: Vec<&str> = parameter_token.split(',').collect();
+            let mut dtmf_tone_is_ok = true;
+
+            // This closure verifies the output of some_number_as_string.parse::<u8>().ok() like calls
+            let validate_digits = |digit_option: Option<u8>| -> Option<u8> {
+                match digit_option {
+                    Some(x) => match x {
+                        0..=100 => Some(x),
+                        _ => None,
+                    },
+                    None => None,
+                }
             };
 
-            if !dtmf_tone_is_ok {
-                break;
+            // This loop does some sanity checking on the passed dtmf tones
+            for dtmf_tone in dtmf_tones {
+                let dtmf_tone_range: Vec<&str> = dtmf_tone.splitn(2, '-').collect();
+
+                dtmf_tone_is_ok = match dtmf_tone_range.len() {
+                    // In this case the dtmf tone is a range
+                    2 => {
+                        match validate_digits(dtmf_tone_range[0].parse::<u8>().ok()) {
+                            Some(l) => match validate_digits(dtmf_tone_range[1].parse::<u8>().ok())
+                            {
+                                Some(u) => {
+                                    // Check that the first part of the range is smaller than the second part
+                                    l < u
+                                }
+                                None => false,
+                            },
+                            None => false,
+                        }
+                    }
+                    // In this case the dtmf tone is a single tone
+                    1 => validate_digits(dtmf_tone.parse::<u8>().ok()).is_some(),
+                    _ => false,
+                };
+
+                if !dtmf_tone_is_ok {
+                    break;
+                }
             }
+
+            // Set the parsed dtmf tones or in case the parsing was insuccessfull, set it to the default "0-15"
+            parameters.dtmf_tones = if dtmf_tone_is_ok {
+                parameter_token.to_string()
+            } else {
+                "0-15".to_string()
+            };
         }
-
-        // Set the parsed dtmf tones or in case the parsing was insuccessfull, set it to the default "0-15"
-        parameters.dtmf_tones = if dtmf_tone_is_ok {
-            parameter_token.to_string()
-        } else {
-            "0-15".to_string()
-        };
     }
-
     Ok(SdpAttribute::Fmtp(SdpAttributeFmtp {
         payload_type: payload_token.parse::<u8>()?,
         parameters,
@@ -3496,7 +3503,11 @@ mod tests {
         assert!(parse_attribute("fmtp:109 111/129;").is_err());
         assert!(parse_attribute("fmtp:109 packetization-mode=3;").is_err());
         assert!(parse_attribute("fmtp:109 maxplaybackrate=48000stereo=1;").is_err());
-        assert!(parse_attribute("fmtp:8 ;maxplaybackrate=48000").is_err());
+        assert!(parse_attribute("fmtp:8 ;maxplaybackrate=48000").is_ok());
+        assert!(parse_attribute("fmtp:8 packetization-mode=2;;maxplaybackrate=48000").is_ok());
+        assert!(parse_attribute("fmtp:8 packetization-mode=2; maxplaybackrate=48000").is_ok());
+        assert!(parse_attribute("fmtp:8 maxplaybackrate=48000;").is_ok());
+        assert!(parse_attribute("fmtp:8 x-google-start-bitrate=800; maxplaybackrate=48000;").is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Allows spaces between parameters
Allows multiple inner semicolons
Allows leading and following semicolons

Adds related tests.
95% of this patch is the indention of a large block.