### PR TITLE
Update minimum version of rust to 1.36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ rust:
   - beta
   - stable
   # minimum stable version
-  - 1.35.0
+  - 1.36.0
 
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A SDP parser written in Rust specifically aimed to handle WebRTC SDP offers and 
 
 ## Dependecies
 
-* Rust >= 1.35.0
+* Rust >= 1.36.0
 * log module
 * serde module
 * serde-derive module


### PR DESCRIPTION
This fixes the build in CI which was broken by a transitive dependency.