### PR TITLE
Update version to 0.3.1 to match most recent tag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrtc-sdp"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Nils Ohlmeier <github@ohlmeier.org>"]
 description = "This create parses strings in the format of the Session Description Protocol according to RFC4566. It specifically supports the subset of features required to support WebRTC according to the JSEP draft."
 repository = "https://github.com/mozilla/webrtc-sdp"


### PR DESCRIPTION
In the tagged version the version number is correct, but that changes was not made on master. This simply corrects that. This is ahead of cutting a new version.