### PR TITLE
Parse Rtx fmtp parameters

### DIFF
--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -577,6 +577,10 @@ pub struct SdpAttributeFmtpParameters {
     // telephone-event
     pub dtmf_tones: String,
 
+    // Rtx
+    pub apt: u8,
+    pub rtx_time: u32,
+
     // Unknown
     pub unknown_tokens: Vec<String>,
 }
@@ -1902,6 +1906,8 @@ fn parse_fmtp(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError> {
         maxplaybackrate: 48000,
         encodings: Vec::new(),
         dtmf_tones: "".to_string(),
+        apt: 0,
+        rtx_time: 0,
         unknown_tokens: Vec::new(),
     };
 
@@ -1982,6 +1988,8 @@ fn parse_fmtp(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError> {
                         parameters.useinbandfec = parse_bool(parameter_val, "useinbandfec")?
                     }
                     "CBR" => parameters.cbr = parse_bool(parameter_val, "cbr")?,
+                    "APT" => parameters.apt = parameter_val.parse::<u8>()?,
+                    "RTX-TIME" => parameters.rtx_time = parameter_val.parse::<u32>()?,
                     _ => parameters
                         .unknown_tokens
                         .push((*parameter_token).to_string()),
@@ -3507,6 +3515,8 @@ mod tests {
         assert!(
             parse_attribute("fmtp:8 x-google-start-bitrate=800; maxplaybackrate=48000;").is_ok()
         );
+        assert!(parse_attribute("fmtp:97 apt=96").is_ok());
+        assert!(parse_attribute("fmtp:97 apt=96;rtx-time=3000").is_ok());
     }
 
     #[test]

--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -542,6 +542,8 @@ mod tests {
                     maxplaybackrate: 48000,
                     encodings: Vec::new(),
                     dtmf_tones: "".to_string(),
+                    apt: 0,
+                    rtx_time: 0,
                     unknown_tokens: Vec::new()
                 }
             },))


### PR DESCRIPTION
For completeness, this also includes rtx-time. It is optional and does not appear to be used by either chromium or jitsi.