### PR TITLE
Support the use of fmt numbers 35 to 63 as dynamic

### DIFF
--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -385,7 +385,7 @@ pub fn parse_media(value: &str) -> Result<SdpType, SdpParserInternalError> {
                     8  |  // PCMA
                     9  |  // G722
                     13 |  // Comfort Noise
-                    96 ..= 127 => (),  // dynamic range
+                    35 ..= 63 | 96 ..= 127 => (),  // dynamic range
                     _ => return Err(SdpParserInternalError::Generic(
                           "format number in media line is out of range".to_string()))
                 };


### PR DESCRIPTION
This extends the acceptable range of dynamic codec fmt numbers to include 35 to 63.