### PR TITLE
Prepping for 0.3.8 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.3.8] - 2021-01-16
+- fmt numbers 35 to 63 are now usable for dynamic allocation
+- parse extmap-allow-mixed as per RFC 8285
 ## [0.3.7] - 2020-11-23
 - Minimum Rust version >= 1.45
 - Added feature for parse object tree wide debug formatting, defaulted to on for now

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrtc-sdp"
-version = "0.3.7"
+version = "0.3.8"
 authors = ["Nils Ohlmeier <github@ohlmeier.org>"]
 description = "This create parses strings in the format of the Session Description Protocol according to RFC4566. It specifically supports the subset of features required to support WebRTC according to the JSEP draft."
 repository = "https://github.com/mozilla/webrtc-sdp"


### PR DESCRIPTION
Cargo.toml, README.md, and CHANGELOG.md updates.