### PR TITLE
Fix seperation of unknown_tokens

### DIFF
--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -624,10 +624,10 @@ impl fmt::Display for SdpAttributeFmtpParameters {
             // rtx
             return write!(f, "{}", rtx);
         }
-        if self.dtmf_tones.len() > 0 {
+        if !self.dtmf_tones.is_empty() {
             // telephone-event
             return write!(f, "{}", self.dtmf_tones);
-        } else if self.encodings.len() > 0 {
+        } else if !self.encodings.is_empty() {
             // red encodings
             return self
                 .encodings

--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -625,8 +625,8 @@ impl fmt::Display for SdpAttributeFmtpParameters {
         }
         write!(
             f,
-            "{parameters}{red}{dtmf}{unknown}",
-            parameters = non_empty_string_vec![
+            "{}",
+            non_empty_string_vec![
                 maybe_print_param(
                     "profile-level-id=",
                     format!("{:06x}", self.profile_level_id),
@@ -652,12 +652,12 @@ impl fmt::Display for SdpAttributeFmtpParameters {
                 maybe_print_bool_param("usedtx", self.usedtx, false),
                 maybe_print_bool_param("stereo", self.stereo, false),
                 maybe_print_bool_param("useinbandfec", self.useinbandfec, false),
-                maybe_print_bool_param("cbr", self.cbr, false)
+                maybe_print_bool_param("cbr", self.cbr, false),
+                maybe_vector_to_string!("{}", self.encodings, "/"),
+                maybe_print_param("", self.dtmf_tones.clone(), "".to_string()),
+                maybe_vector_to_string!("{}", self.unknown_tokens, ",")
             ]
-            .join(";"),
-            red = maybe_vector_to_string!("{}", self.encodings, "/"),
-            dtmf = maybe_print_param("", self.dtmf_tones.clone(), "".to_string()),
-            unknown = maybe_vector_to_string!("{}", self.unknown_tokens, ",")
+            .join(";")
         )
     }
 }
@@ -4409,5 +4409,37 @@ mod tests {
     #[test]
     fn test_parse_unknown_attribute() {
         assert!(parse_attribute("unknown").is_err())
+    }
+
+    #[test]
+    fn test_serialize_fmtp_parameters_unknown_tokens() {
+        let att = SdpAttributeFmtpParameters {
+            packetization_mode: 1,
+            level_asymmetry_allowed: false,
+            profile_level_id: 0x0042_0010,
+            max_fs: 0,
+            max_cpb: 0,
+            max_dpb: 0,
+            max_br: 0,
+            max_mbps: 0,
+            usedtx: false,
+            stereo: false,
+            useinbandfec: false,
+            cbr: false,
+            max_fr: 0,
+            maxplaybackrate: 48000,
+            maxaveragebitrate: 0,
+            ptime: 0,
+            minptime: 0,
+            maxptime: 0,
+            encodings: Vec::new(),
+            dtmf_tones: "".to_string(),
+            rtx: None,
+            unknown_tokens: vec!["sprop-parameter-sets=Z0LAFYyNQKD5APCIRqA=,aM48gA==".to_string()],
+        };
+        assert_eq!(
+            format!("{}", att),
+            "packetization-mode=1;sprop-parameter-sets=Z0LAFYyNQKD5APCIRqA=,aM48gA=="
+        );
     }
 }

--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -621,8 +621,22 @@ pub struct SdpAttributeFmtpParameters {
 impl fmt::Display for SdpAttributeFmtpParameters {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(ref rtx) = self.rtx {
+            // rtx
             return write!(f, "{}", rtx);
         }
+        if self.dtmf_tones.len() > 0 {
+            // telephone-event
+            return write!(f, "{}", self.dtmf_tones);
+        } else if self.encodings.len() > 0 {
+            // red encodings
+            return self
+                .encodings
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<String>>()
+                .join("/")
+                .fmt(f);
+        };
         write!(
             f,
             "{}",
@@ -653,8 +667,6 @@ impl fmt::Display for SdpAttributeFmtpParameters {
                 maybe_print_bool_param("stereo", self.stereo, false),
                 maybe_print_bool_param("useinbandfec", self.useinbandfec, false),
                 maybe_print_bool_param("cbr", self.cbr, false),
-                maybe_vector_to_string!("{}", self.encodings, "/"),
-                maybe_print_param("", self.dtmf_tones.clone(), "".to_string()),
                 maybe_vector_to_string!("{}", self.unknown_tokens, ",")
             ]
             .join(";")

--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -3684,6 +3684,9 @@ mod tests {
         );
         check_parse_and_serialize("fmtp:97 apt=96");
         check_parse_and_serialize("fmtp:97 apt=96;rtx-time=3000");
+        check_parse_and_serialize(
+            "fmtp:102 packetization-mode=1;sprop-parameter-sets=Z0LAFYyNQKD5APCIRqA=,aM48gA==",
+        );
     }
 
     #[test]
@@ -4409,37 +4412,5 @@ mod tests {
     #[test]
     fn test_parse_unknown_attribute() {
         assert!(parse_attribute("unknown").is_err())
-    }
-
-    #[test]
-    fn test_serialize_fmtp_parameters_unknown_tokens() {
-        let att = SdpAttributeFmtpParameters {
-            packetization_mode: 1,
-            level_asymmetry_allowed: false,
-            profile_level_id: 0x0042_0010,
-            max_fs: 0,
-            max_cpb: 0,
-            max_dpb: 0,
-            max_br: 0,
-            max_mbps: 0,
-            usedtx: false,
-            stereo: false,
-            useinbandfec: false,
-            cbr: false,
-            max_fr: 0,
-            maxplaybackrate: 48000,
-            maxaveragebitrate: 0,
-            ptime: 0,
-            minptime: 0,
-            maxptime: 0,
-            encodings: Vec::new(),
-            dtmf_tones: "".to_string(),
-            rtx: None,
-            unknown_tokens: vec!["sprop-parameter-sets=Z0LAFYyNQKD5APCIRqA=,aM48gA==".to_string()],
-        };
-        assert_eq!(
-            format!("{}", att),
-            "packetization-mode=1;sprop-parameter-sets=Z0LAFYyNQKD5APCIRqA=,aM48gA=="
-        );
     }
 }


### PR DESCRIPTION
Nils, it looks like the `red`, `dtmf`, and `unknown_parameters` were being concatenated incorrectly on the FTMP parameters.