### PR TITLE
Add additional allowed sdp payload types to parse_media.

### DIFF
--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -380,12 +380,41 @@ pub fn parse_media(value: &str) -> Result<SdpType, SdpParserInternalError> {
             let mut fmt_vec: Vec<u32> = vec![];
             for num in fmt_slice {
                 let fmt_num = num.parse::<u32>()?;
+                // The folllowing is https://tools.ietf.org/html/rfc3551#section-6
+                // with restrictions added from
+                // https://tools.ietf.org/html/rfc5761#section-4
                 match fmt_num {
                     0  |  // PCMU
+                    3  |  // GSM
+                    4  |  // G723
+                    5  |  // DVI4
+                    6  |  // DVI4
+                    7  |  // LPC
                     8  |  // PCMA
                     9  |  // G722
+                    10 |  // L16
+                    11 |  // L16
+                    12 |  // QCELP
                     13 |  // Comfort Noise
-                    35 ..= 63 | 96 ..= 127 => (),  // dynamic range
+                    14 |  // MPA
+                    15 |  // G728
+                    16 |  // DVI4
+                    17 |  // DVI4
+                    18 |  // G729
+                    20 ..= 24 | // unassigned
+                    25 |  // CelB
+                    26 |  // JPEG
+                    27 |  // unassigned
+                    28 |  // nv
+                    29 |  // unassigned
+                    30 |  // unassigned
+                    31 |  // H261
+                    32 |  // MPV
+                    33 |  // MP2T
+                    34 |  // H263
+                    35 ..= 63 | // unassigned
+                    // rfc5761 says 64-95 MUST NOT be used
+                    96 ..= 127 => (),  // dynamic range
                     _ => return Err(SdpParserInternalError::Generic(
                           "format number in media line is out of range".to_string()))
                 };

--- a/src/media_type_tests.rs
+++ b/src/media_type_tests.rs
@@ -307,6 +307,19 @@ fn test_media_invalid_transport() {
 #[test]
 fn test_media_invalid_payload() {
     assert!(parse_media("audio 9 UDP/TLS/RTP/SAVPF 300").is_err());
+
+    // reserved PTs from https://tools.ietf.org/html/rfc3551#section-6
+    assert!(parse_media("audio 9 UDP/TLS/RTP/SAVPF 1").is_err()); // reserved audio
+    assert!(parse_media("audio 9 UDP/TLS/RTP/SAVPF 2").is_err()); // reserved audio
+    assert!(parse_media("audio 9 UDP/TLS/RTP/SAVPF 19").is_err()); // reserved audio
+
+    // reserved PTs (64-95) from https://tools.ietf.org/html/rfc5761#section-4
+    for pt in 64..=95 {
+        assert!(
+            parse_media(&format!("audio 9 UDP/TLS/RTP/SAVPF {}", pt)).is_err(),
+            format!("pt '{}' should be reserved", pt)
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
See https://tools.ietf.org/html/rfc3551#section-6
and https://tools.ietf.org/html/rfc5761#section-4