### PR TITLE
Add support for RFC8858 rtcp-mux-only

### DIFF
--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -1221,7 +1221,7 @@ pub enum SdpAttribute {
     Rtcp(SdpAttributeRtcp),
     Rtcpfb(SdpAttributeRtcpFb),
     RtcpMux,
-    RtcpMuxOnly,                    // RFC8858
+    RtcpMuxOnly, // RFC8858
     RtcpRsize,
     Sctpmap(SdpAttributeSctpmap),
     SctpPort(u64),

--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -1221,7 +1221,7 @@ pub enum SdpAttribute {
     Rtcp(SdpAttributeRtcp),
     Rtcpfb(SdpAttributeRtcpFb),
     RtcpMux,
-    RtcpMuxOnly,
+    RtcpMuxOnly,                    // RFC8858
     RtcpRsize,
     Sctpmap(SdpAttributeSctpmap),
     SctpPort(u64),

--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -2714,10 +2714,7 @@ fn parse_msid(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError> {
         }
         Some(x) => x.to_string(),
     };
-    let appdata = match tokens.next() {
-        None => None,
-        Some(x) => Some(x.to_string()),
-    };
+    let appdata = tokens.next().map(|x| x.to_string());
     Ok(SdpAttribute::Msid(SdpAttributeMsid { id, appdata }))
 }
 

--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -1221,6 +1221,7 @@ pub enum SdpAttribute {
     Rtcp(SdpAttributeRtcp),
     Rtcpfb(SdpAttributeRtcpFb),
     RtcpMux,
+    RtcpMuxOnly,
     RtcpRsize,
     Sctpmap(SdpAttributeSctpmap),
     SctpPort(u64),
@@ -1252,6 +1253,7 @@ impl SdpAttribute {
             | SdpAttribute::Rtcp(..)
             | SdpAttribute::Rtcpfb(..)
             | SdpAttribute::RtcpMux
+            | SdpAttribute::RtcpMuxOnly
             | SdpAttribute::RtcpRsize
             | SdpAttribute::Sctpmap(..)
             | SdpAttribute::SctpPort(..)
@@ -1315,6 +1317,7 @@ impl SdpAttribute {
             | SdpAttribute::Rtcp(..)
             | SdpAttribute::Rtcpfb(..)
             | SdpAttribute::RtcpMux
+            | SdpAttribute::RtcpMuxOnly
             | SdpAttribute::RtcpRsize
             | SdpAttribute::Sctpmap(..)
             | SdpAttribute::SctpPort(..)
@@ -1341,8 +1344,8 @@ impl FromStr for SdpAttribute {
         if tokens.len() > 1 {
             match name.as_str() {
                 "bundle-only" | "end-of-candidates" | "extmap-allow-mixed" | "ice-lite"
-                | "ice-mismatch" | "inactive" | "recvonly" | "rtcp-mux" | "rtcp-rsize"
-                | "sendonly" | "sendrecv" => {
+                | "ice-mismatch" | "inactive" | "recvonly" | "rtcp-mux" | "rtcp-mux-only"
+                | "rtcp-rsize" | "sendonly" | "sendrecv" => {
                     return Err(SdpParserInternalError::Generic(format!(
                         "{} attribute is not allowed to have a value",
                         name
@@ -1373,6 +1376,7 @@ impl FromStr for SdpAttribute {
             "rid" => parse_rid(val),
             "recvonly" => Ok(SdpAttribute::Recvonly),
             "rtcp-mux" => Ok(SdpAttribute::RtcpMux),
+            "rtcp-mux-only" => Ok(SdpAttribute::RtcpMuxOnly),
             "rtcp-rsize" => Ok(SdpAttribute::RtcpRsize),
             "sendonly" => Ok(SdpAttribute::Sendonly),
             "sendrecv" => Ok(SdpAttribute::Sendrecv),
@@ -1438,6 +1442,7 @@ impl fmt::Display for SdpAttribute {
             SdpAttribute::Rtcp(ref a) => attr_to_string(a.to_string()),
             SdpAttribute::Rtcpfb(ref a) => attr_to_string(a.to_string()),
             SdpAttribute::RtcpMux => SdpAttributeType::RtcpMux.to_string(),
+            SdpAttribute::RtcpMuxOnly => SdpAttributeType::RtcpMuxOnly.to_string(),
             SdpAttribute::RtcpRsize => SdpAttributeType::RtcpRsize.to_string(),
             SdpAttribute::Sctpmap(ref a) => attr_to_string(a.to_string()),
             SdpAttribute::SctpPort(ref a) => attr_to_string(a.to_string()),
@@ -1504,6 +1509,7 @@ pub enum SdpAttributeType {
     Rtcp,
     Rtcpfb,
     RtcpMux,
+    RtcpMuxOnly,
     RtcpRsize,
     Sctpmap,
     SctpPort,
@@ -1549,6 +1555,7 @@ impl<'a> From<&'a SdpAttribute> for SdpAttributeType {
             SdpAttribute::Rtcp { .. } => SdpAttributeType::Rtcp,
             SdpAttribute::Rtcpfb { .. } => SdpAttributeType::Rtcpfb,
             SdpAttribute::RtcpMux { .. } => SdpAttributeType::RtcpMux,
+            SdpAttribute::RtcpMuxOnly { .. } => SdpAttributeType::RtcpMuxOnly,
             SdpAttribute::RtcpRsize { .. } => SdpAttributeType::RtcpRsize,
             SdpAttribute::Rtpmap { .. } => SdpAttributeType::Rtpmap,
             SdpAttribute::Sctpmap { .. } => SdpAttributeType::Sctpmap,
@@ -1598,6 +1605,7 @@ impl fmt::Display for SdpAttributeType {
             SdpAttributeType::Rtcp => "rtcp",
             SdpAttributeType::Rtcpfb => "rtcp-fb",
             SdpAttributeType::RtcpMux => "rtcp-mux",
+            SdpAttributeType::RtcpMuxOnly => "rtcp-mux-only",
             SdpAttributeType::RtcpRsize => "rtcp-rsize",
             SdpAttributeType::Sctpmap => "sctpmap",
             SdpAttributeType::SctpPort => "sctp-port",

--- a/src/attribute_type_tests.rs
+++ b/src/attribute_type_tests.rs
@@ -926,6 +926,15 @@ fn test_parse_attribute_rtcp_mux() {
 }
 
 #[test]
+fn test_parse_attribute_rtcp_mux_only() {
+    let check_parse = make_check_parse!(SdpAttribute::RtcpMuxOnly);
+    let check_parse_and_serialize = make_check_parse_and_serialize!(check_parse);
+
+    check_parse_and_serialize("rtcp-mux-only");
+    assert!(parse_attribute("rtcp-mux-only bar").is_err());
+}
+
+#[test]
 fn test_parse_attribute_rtcp_rsize() {
     let check_parse = make_check_parse!(SdpAttribute::RtcpRsize);
     let check_parse_and_serialize = make_check_parse_and_serialize!(check_parse);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -836,7 +836,7 @@ fn parse_sdp_vector(lines: &mut Vec<SdpLine>) -> Result<SdpSession, SdpParserErr
 
     let _media_pos = lines
         .iter()
-        .position(|ref l| matches!(l.sdp_type, SdpType::Media(_)));
+        .position(|l| matches!(l.sdp_type, SdpType::Media(_)));
 
     match _media_pos {
         Some(p) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -726,7 +726,7 @@ fn sanity_check_sdp_session(session: &SdpSession) -> Result<(), SdpParserError> 
             && msection.get_attribute(SdpAttributeType::RtcpMux).is_none()
         {
             return Err(make_seq_error(
-                "rtcp-mux-only requires to have a rtcp-mux attribute as well",
+                "rtcp-mux-only media sections must also contain the rtcp-mux attribute",
             ));
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -720,6 +720,16 @@ fn sanity_check_sdp_session(session: &SdpSession) -> Result<(), SdpParserError> 
             }
         }
 
+        if msection
+            .get_attribute(SdpAttributeType::RtcpMuxOnly)
+            .is_some()
+            && msection.get_attribute(SdpAttributeType::RtcpMux).is_none()
+        {
+            return Err(make_seq_error(
+                "rtcp-mux-only requires to have a rtcp-mux attribute as well",
+            ));
+        }
+
         let rids: Vec<&SdpAttributeRid> = msection
             .get_attributes()
             .iter()

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -678,6 +678,22 @@ fn test_parse_sdp_vector_with_media_section() -> Result<(), SdpParserError> {
 }
 
 #[test]
+fn test_parse_sdp_vector_with_missing_rtcp_mux() -> Result<(), SdpParserError> {
+    let mut lines: Vec<SdpLine> = vec![parse_sdp_line("v=0", 1)?];
+    lines.push(parse_sdp_line(
+        "o=ausername 4294967296 2 IN IP4 127.0.0.1",
+        1,
+    )?);
+    lines.push(parse_sdp_line("s=SIP Call", 1)?);
+    lines.push(parse_sdp_line("t=0 0", 1)?);
+    lines.push(parse_sdp_line("m=video 56436 RTP/SAVPF 120", 1)?);
+    lines.push(parse_sdp_line("c=IN IP6 ::1", 1)?);
+    lines.push(parse_sdp_line("a=rtcp-mux-only", 1)?);
+    assert!(parse_sdp_vector(&mut lines).is_err());
+    Ok(())
+}
+
+#[test]
 fn test_parse_sdp_vector_too_short() -> Result<(), SdpParserError> {
     let mut lines: Vec<SdpLine> = vec![parse_sdp_line("v=0", 1)?];
     assert!(parse_sdp_vector(&mut lines).is_err());

--- a/tests/parse_sdp_tests.rs
+++ b/tests/parse_sdp_tests.rs
@@ -707,6 +707,7 @@ a=mid:audio\r\n
 a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\n
 a=sendrecv\r\n
 a=rtcp-mux\r\n
+a=rtcp-mux-only\r\n
 a=rtpmap:111 opus/48000/2\r\n
 a=rtcp-fb:111 transport-cc\r\n
 a=fmtp:111 minptime=10;useinbandfec=1\r\n


### PR DESCRIPTION
This PR adds support for RFC8858 rtcp-mux-only attribute as required by the JSEP spec.