### PR TITLE
Fix visibility for parse_sdp_line()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -543,7 +543,7 @@ fn parse_timing(value: &str) -> Result<SdpType, SdpParserInternalError> {
     Ok(SdpType::Timing(t))
 }
 
-fn parse_sdp_line(line: &str, line_number: usize) -> Result<SdpLine, SdpParserError> {
+pub fn parse_sdp_line(line: &str, line_number: usize) -> Result<SdpLine, SdpParserError> {
     if line.find('=') == None {
         return Err(SdpParserError::Line {
             error: SdpParserInternalError::Generic("missing = character in line".to_string()),


### PR DESCRIPTION
`parse_media_vector()` has public visibility, but `parse_sdp_line()` does not, making the former impossible to use from outside of the library.