### PR TITLE
:enh: support GSM RTP payload type

### DIFF
--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -382,6 +382,7 @@ pub fn parse_media(value: &str) -> Result<SdpType, SdpParserInternalError> {
                 let fmt_num = num.parse::<u32>()?;
                 match fmt_num {
                     0  |  // PCMU
+                    3  |  // GSM
                     8  |  // PCMA
                     9  |  // G722
                     13 |  // Comfort Noise

--- a/src/media_type_tests.rs
+++ b/src/media_type_tests.rs
@@ -305,6 +305,11 @@ fn test_media_invalid_transport() {
 }
 
 #[test]
+fn test_media_gsm_payload_type() {
+    assert!(parse_media("audio 9 RTP/AVP 3").is_ok());
+}
+
+#[test]
 fn test_media_invalid_payload() {
     assert!(parse_media("audio 9 UDP/TLS/RTP/SAVPF 300").is_err());
 }


### PR DESCRIPTION
As titled, support RTP payload type 3 (GSM) among media line fmt values