### PR TITLE
Fix clippy warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,6 @@ workflows:
           matrix:
             parameters:
               features: ["", "serialize"]
-              rustversion: ["1.45.0", "1.57.0"]
-              latestrustversion: ["1.57.0"]
+              rustversion: ["1.58.0", "1.67.1"]
+              latestrustversion: ["1.67.1"]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,6 @@ workflows:
           matrix:
             parameters:
               features: ["", "serialize"]
-              rustversion: ["1.58.0", "1.67.1"]
-              latestrustversion: ["1.67.1"]
+              rustversion: ["1.58.0", "1.67"]
+              latestrustversion: ["1.67"]
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A SDP parser written in Rust specifically aimed to handle WebRTC SDP offers and 
 
 ## Dependecies
 
-* Rust >= 1.45.0
+* Rust >= 1.58.0
 * log module
 * serde module
 * serde-derive module

--- a/examples/file_parser.rs
+++ b/examples/file_parser.rs
@@ -25,7 +25,7 @@ fn main() {
     let path = Path::new(filename.as_str());
     let display = path.display();
 
-    let mut file = match File::open(&path) {
+    let mut file = match File::open(path) {
         Err(why) => panic!("Failed to open {}: {}", display, why),
         Ok(file) => file,
     };
@@ -61,7 +61,7 @@ fn main() {
     let res = webrtc_sdp::parse_sdp(&s, true);
     match res {
         Err(why) => panic!("Failed to parse SDP with error: {}", why),
-        Ok(sdp) => println!("Parsed SDP structure:\n{:#?}", sdp),
+        Ok(sdp) => println!("Parsed SDP structure:\n{sdp:#?}"),
     }
 
     if expect_failure {

--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -221,7 +221,7 @@ impl fmt::Display for SdpAttributeCandidate {
             unknown = self
                 .unknown_extensions
                 .iter()
-                .map(|&(ref name, ref value)| format!(" {} {}", name, value))
+                .map(|(name, value)| format!(" {name} {value}"))
                 .collect::<String>()
         )
     }
@@ -308,9 +308,9 @@ pub enum SdpAttributeDtlsMessage {
 
 impl fmt::Display for SdpAttributeDtlsMessage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            SdpAttributeDtlsMessage::Client(ref msg) => format!("client {}", msg),
-            SdpAttributeDtlsMessage::Server(ref msg) => format!("server {}", msg),
+        match self {
+            SdpAttributeDtlsMessage::Client(msg) => format!("client {msg}"),
+            SdpAttributeDtlsMessage::Server(msg) => format!("server {msg}"),
         }
         .fmt(f)
     }
@@ -622,7 +622,7 @@ impl fmt::Display for SdpAttributeFmtpParameters {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(ref rtx) = self.rtx {
             // rtx
-            return write!(f, "{}", rtx);
+            return write!(f, "{rtx}");
         }
         if !self.dtmf_tones.is_empty() {
             // telephone-event
@@ -713,8 +713,7 @@ impl SdpAttributeFingerprintHashType {
             "sha-384" => Ok(Self::Sha384),
             "sha-512" => Ok(Self::Sha512),
             unknown => Err(SdpParserInternalError::Unsupported(format!(
-                "fingerprint contains an unsupported hash algorithm '{}'",
-                unknown
+                "fingerprint contains an unsupported hash algorithm '{unknown}'"
             ))),
         }
     }
@@ -786,8 +785,7 @@ impl TryFrom<(SdpAttributeFingerprintHashType, Vec<u8>)> for SdpAttributeFingerp
                 fingerprint,
             }),
             (a, b) => Err(SdpParserInternalError::Generic(format!(
-                "Hash algoritm expects {} fingerprint bytes not {}",
-                a, b
+                "Hash algoritm expects {a} fingerprint bytes not {b}",
             ))),
         }
     }
@@ -802,7 +800,7 @@ impl fmt::Display for SdpAttributeFingerprint {
             fp = self
                 .fingerprint
                 .iter()
-                .map(|byte| format!("{:02X}", byte))
+                .map(|byte| format!("{byte:02X}"))
                 .collect::<Vec<String>>()
                 .join(":")
         )
@@ -846,11 +844,11 @@ impl fmt::Display for SdpAttributeImageAttrXyRange {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             SdpAttributeImageAttrXyRange::Range(ref min, ref max, ref step_opt) => {
-                write!(f, "[{}:", min)?;
+                write!(f, "[{min}:")?;
                 if step_opt.is_some() {
                     write!(f, "{}:", step_opt.unwrap())?;
                 }
-                write!(f, "{}]", max)
+                write!(f, "{max}]")
             }
             SdpAttributeImageAttrXyRange::DiscreteValues(ref values) => {
                 write!(f, "{}", imageattr_discrete_value_list_to_string(values))
@@ -868,9 +866,9 @@ pub enum SdpAttributeImageAttrSRange {
 
 impl fmt::Display for SdpAttributeImageAttrSRange {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            SdpAttributeImageAttrSRange::Range(ref min, ref max) => write!(f, "[{}-{}]", min, max),
-            SdpAttributeImageAttrSRange::DiscreteValues(ref values) => {
+        match self {
+            SdpAttributeImageAttrSRange::Range(min, max) => write!(f, "[{min}-{max}]"),
+            SdpAttributeImageAttrSRange::DiscreteValues(values) => {
                 write!(f, "{}", imageattr_discrete_value_list_to_string(values))
             }
         }
@@ -1110,7 +1108,7 @@ impl fmt::Display for SdpAttributeRid {
             .as_str()
             {
                 "" => "".to_string(),
-                x => format!(" {}", x),
+                x => format!(" {x}"),
             }
         )
     }
@@ -1195,7 +1193,7 @@ impl SdpAttributeSsrc {
     }
 
     fn set_attribute(&mut self, a: &str) {
-        if a.find(':') == None {
+        if a.find(':').is_none() {
             self.attribute = Some(a.to_string());
         } else {
             let v: Vec<&str> = a.splitn(2, ':').collect();
@@ -1415,8 +1413,7 @@ impl FromStr for SdpAttribute {
                 | "ice-mismatch" | "inactive" | "recvonly" | "rtcp-mux" | "rtcp-mux-only"
                 | "rtcp-rsize" | "sendonly" | "sendrecv" => {
                     return Err(SdpParserInternalError::Generic(format!(
-                        "{} attribute is not allowed to have a value",
-                        name
+                        "{name} attribute is not allowed to have a value",
                     )));
                 }
                 _ => (),
@@ -1466,8 +1463,7 @@ impl FromStr for SdpAttribute {
             "simulcast" => parse_simulcast(val),
             "ssrc" => parse_ssrc(val),
             _ => Err(SdpParserInternalError::Unsupported(format!(
-                "Unknown attribute type {}",
-                name
+                "Unknown attribute type {name}",
             ))),
         }
     }
@@ -1710,8 +1706,7 @@ fn parse_single_direction(to_parse: &str) -> Result<SdpSingleDirection, SdpParse
         "send" => Ok(SdpSingleDirection::Send),
         "recv" => Ok(SdpSingleDirection::Recv),
         x => Err(SdpParserInternalError::Generic(format!(
-            "Unknown direction description found: '{:}'",
-            x
+            "Unknown direction description found: '{x:}'"
         ))),
     }
 }
@@ -1736,8 +1731,7 @@ fn parse_ssrc_group(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalErr
             "SIM" => SdpSsrcGroupSemantic::Sim,
             unknown => {
                 return Err(SdpParserInternalError::Unsupported(format!(
-                    "Unknown ssrc semantic '{:?}' found",
-                    unknown
+                    "Unknown ssrc semantic '{unknown:?}' found"
                 )));
             }
         },
@@ -1773,8 +1767,7 @@ fn parse_sctp_port(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalErro
     let port = to_parse.parse()?;
     if port > 65535 {
         return Err(SdpParserInternalError::Generic(format!(
-            "Sctpport port {} can only be a bit 16bit number",
-            port
+            "Sctpport port {port} can only be a bit 16bit number"
         )));
     }
     Ok(SdpAttribute::SctpPort(port))
@@ -1948,8 +1941,7 @@ fn parse_dtls_message(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalE
         "server" => SdpAttributeDtlsMessage::Server(tokens[1].to_string()),
         e => {
             return Err(SdpParserInternalError::Generic(format!(
-                "dtls-message has unknown role token '{}'",
-                e
+                "dtls-message has unknown role token '{e}'"
             )));
         }
     }))
@@ -1991,7 +1983,7 @@ fn parse_extmap(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError> 
     }
     let id: u16;
     let mut direction: Option<SdpAttributeDirection> = None;
-    if tokens[0].find('/') == None {
+    if tokens[0].find('/').is_none() {
         id = tokens[0].parse::<u16>()?;
     } else {
         let id_dir: Vec<&str> = tokens[0].splitn(2, '/').collect();
@@ -2121,8 +2113,7 @@ fn parse_fmtp(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError> {
                             0 => Ok(false),
                             1 => Ok(true),
                             _ => Err(SdpParserInternalError::Generic(format!(
-                                "The fmtp parameter '{:}' must be 0 or 1",
-                                param_name
+                                "The fmtp parameter '{param_name:}' must be 0 or 1"
                             ))),
                         }
                     };
@@ -2300,8 +2291,7 @@ fn parse_group(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError> {
             "BUNDLE" => SdpAttributeGroupSemantic::Bundle,
             unknown => {
                 return Err(SdpParserInternalError::Unsupported(format!(
-                    "Unknown group semantic '{:?}' found",
-                    unknown
+                    "Unknown group semantic '{unknown:?}' found",
                 )));
             }
         },
@@ -3052,8 +3042,7 @@ fn parse_rtcp_fb(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError>
             "transport-cc" => SdpAttributeRtcpFbType::TransCc,
             _ => {
                 return Err(SdpParserInternalError::Unsupported(format!(
-                    "Unknown rtcpfb feedback type: {:?}",
-                    x
+                    "Unknown rtcpfb feedback type: {x:?}"
                 )));
             }
         },
@@ -3071,8 +3060,7 @@ fn parse_rtcp_fb(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError>
                 "rpsi" | "app" => (*x).to_string(),
                 _ => {
                     return Err(SdpParserInternalError::Unsupported(format!(
-                        "Unknown rtcpfb ack parameter: {:?}",
-                        x
+                        "Unknown rtcpfb ack parameter: {x:?}"
                     )));
                 }
             },
@@ -3087,8 +3075,7 @@ fn parse_rtcp_fb(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError>
                 "fir" | "tmmbr" | "tstr" | "vbcm" => (*x).to_string(),
                 _ => {
                     return Err(SdpParserInternalError::Unsupported(format!(
-                        "Unknown rtcpfb ccm parameter: {:?}",
-                        x
+                        "Unknown rtcpfb ccm parameter: {x:?}"
                     )));
                 }
             },
@@ -3099,8 +3086,7 @@ fn parse_rtcp_fb(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError>
                 "sli" | "pli" | "rpsi" | "app" => (*x).to_string(),
                 _ => {
                     return Err(SdpParserInternalError::Unsupported(format!(
-                        "Unknown rtcpfb nack parameter: {:?}",
-                        x
+                        "Unknown rtcpfb nack parameter: {x:?}"
                     )));
                 }
             },
@@ -3111,8 +3097,7 @@ fn parse_rtcp_fb(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError>
                 _ if x.parse::<u32>().is_ok() => (*x).to_string(),
                 _ => {
                     return Err(SdpParserInternalError::Generic(format!(
-                        "Unknown rtcpfb trr-int parameter: {:?}",
-                        x
+                        "Unknown rtcpfb trr-int parameter: {x:?}"
                     )));
                 }
             },
@@ -3125,8 +3110,7 @@ fn parse_rtcp_fb(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError>
         SdpAttributeRtcpFbType::Remb | SdpAttributeRtcpFbType::TransCc => match tokens.get(2) {
             Some(x) => {
                 return Err(SdpParserInternalError::Unsupported(format!(
-                    "Unknown rtcpfb {} parameter: {:?}",
-                    feedback_type, x
+                    "Unknown rtcpfb {feedback_type} parameter: {x:?}"
                 )));
             }
             None => "".to_string(),
@@ -3213,8 +3197,7 @@ fn parse_simulcast_version_list(
                 descriptor_versionlist_pair.next().unwrap(),
             )),
             descriptor => Err(SdpParserInternalError::Generic(format!(
-                "Simulcast attribute has unknown list descriptor '{:?}'",
-                descriptor
+                "Simulcast attribute has unknown list descriptor '{descriptor:?}'"
             ))),
         }
     } else {
@@ -3249,7 +3232,7 @@ fn parse_simulcast_version_list(
 // ; rid-id defined in [I-D.ietf-mmusic-rid]
 fn parse_simulcast(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError> {
     // TODO: Bug 1225877: Stop accepting all kinds of whitespace here, and only accept SP
-    let mut tokens = to_parse.trim().split_whitespace();
+    let mut tokens = to_parse.split_whitespace();
     let first_direction = match tokens.next() {
         Some(x) => parse_single_direction(x)?,
         None => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,27 +36,25 @@ impl fmt::Display for SdpParserInternalError {
         match *self {
             SdpParserInternalError::UnknownAddressType(ref unknown) => write!(
                 f,
-                "{}: {}",
-                INTERNAL_ERROR_MESSAGE_UNKNOWN_ADDRESS_TYPE, unknown
+                "{INTERNAL_ERROR_MESSAGE_UNKNOWN_ADDRESS_TYPE}: {unknown}"
             ),
             SdpParserInternalError::AddressTypeMismatch { found, expected } => write!(
                 f,
-                "{}: {}, {}",
-                INTERNAL_ERROR_MESSAGE_ADDRESS_TYPE_MISMATCH, found, expected
+                "{INTERNAL_ERROR_MESSAGE_ADDRESS_TYPE_MISMATCH}: {found}, {expected}"
             ),
-            SdpParserInternalError::Generic(ref message) => write!(f, "Parsing error: {}", message),
+            SdpParserInternalError::Generic(ref message) => write!(f, "Parsing error: {message}"),
             SdpParserInternalError::Unsupported(ref message) => {
-                write!(f, "Unsupported parsing error: {}", message)
+                write!(f, "Unsupported parsing error: {message}")
             }
             SdpParserInternalError::Integer(ref error) => {
-                write!(f, "Integer parsing error: {}", error)
+                write!(f, "Integer parsing error: {error}")
             }
-            SdpParserInternalError::Float(ref error) => write!(f, "Float parsing error: {}", error),
+            SdpParserInternalError::Float(ref error) => write!(f, "Float parsing error: {error}"),
             SdpParserInternalError::Domain(ref error) => {
-                write!(f, "Domain name parsing error: {}", error)
+                write!(f, "Domain name parsing error: {error}")
             }
             SdpParserInternalError::IpAddress(ref error) => {
-                write!(f, "IP address parsing error: {}", error)
+                write!(f, "IP address parsing error: {error}")
             }
         }
     }
@@ -149,24 +147,16 @@ impl fmt::Display for SdpParserError {
                 ref error,
                 ref line,
                 ref line_number,
-            } => write!(
-                f,
-                "Line error: {} in line({}): {}",
-                error, line_number, line
-            ),
+            } => write!(f, "Line error: {error} in line({line_number}): {line}"),
             SdpParserError::Unsupported {
                 ref error,
                 ref line,
                 ref line_number,
-            } => write!(
-                f,
-                "Unsupported: {} in line({}): {}",
-                error, line_number, line
-            ),
+            } => write!(f, "Unsupported: {error} in line({line_number}): {line}",),
             SdpParserError::Sequence {
                 ref message,
                 ref line_number,
-            } => write!(f, "Sequence error in line({}): {}", line_number, message),
+            } => write!(f, "Sequence error in line({line_number}): {message}"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,20 +105,12 @@ impl Serialize for SdpParserError {
             },
         )?;
         match self {
-            SdpParserError::Line {
-                error,
-                line,
-                ..
-            } => {
+            SdpParserError::Line { error, line, .. } => {
                 state.serialize_field("type", "Line")?;
                 state.serialize_field("message", &format!("{error}"))?;
                 state.serialize_field("line", line)?
             }
-            SdpParserError::Unsupported {
-                error,
-                line,
-                ..
-            } => {
+            SdpParserError::Unsupported { error, line, .. } => {
                 state.serialize_field("type", "Unsupported")?;
                 state.serialize_field("message", &format!("{error}"))?;
                 state.serialize_field("line", line)?
@@ -144,18 +136,18 @@ impl fmt::Display for SdpParserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             SdpParserError::Line {
-                 error,
-                 line,
-                 line_number,
+                error,
+                line,
+                line_number,
             } => write!(f, "Line error: {error} in line({line_number}): {line}"),
             SdpParserError::Unsupported {
-                 error,
-                 line,
-                 line_number,
+                error,
+                line,
+                line_number,
             } => write!(f, "Unsupported: {error} in line({line_number}): {line}",),
             SdpParserError::Sequence {
-                 message,
-                 line_number,
+                message,
+                line_number,
             } => write!(f, "Sequence error in line({line_number}): {message}"),
         }
     }
@@ -164,8 +156,9 @@ impl fmt::Display for SdpParserError {
 impl Error for SdpParserError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
-            SdpParserError::Line { error, .. }
-            | SdpParserError::Unsupported { error, .. } => Some(error),
+            SdpParserError::Line { error, .. } | SdpParserError::Unsupported { error, .. } => {
+                Some(error)
+            }
             // Can't tell much more about our internal errors
             _ => None,
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -99,33 +99,33 @@ impl Serialize for SdpParserError {
     {
         let mut state = serializer.serialize_struct(
             "error",
-            match *self {
+            match self {
                 SdpParserError::Sequence { .. } => 3,
                 _ => 4,
             },
         )?;
-        match *self {
+        match self {
             SdpParserError::Line {
-                ref error,
-                ref line,
+                error,
+                line,
                 ..
             } => {
                 state.serialize_field("type", "Line")?;
-                state.serialize_field("message", &format!("{}", error))?;
-                state.serialize_field("line", &line)?
+                state.serialize_field("message", &format!("{error}"))?;
+                state.serialize_field("line", line)?
             }
             SdpParserError::Unsupported {
-                ref error,
-                ref line,
+                error,
+                line,
                 ..
             } => {
                 state.serialize_field("type", "Unsupported")?;
-                state.serialize_field("message", &format!("{}", error))?;
-                state.serialize_field("line", &line)?
+                state.serialize_field("message", &format!("{error}"))?;
+                state.serialize_field("line", line)?
             }
-            SdpParserError::Sequence { ref message, .. } => {
+            SdpParserError::Sequence { message, .. } => {
                 state.serialize_field("type", "Sequence")?;
-                state.serialize_field("message", &message)?;
+                state.serialize_field("message", message)?;
             }
         };
         state.serialize_field(
@@ -142,20 +142,20 @@ impl Serialize for SdpParserError {
 
 impl fmt::Display for SdpParserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
+        match self {
             SdpParserError::Line {
-                ref error,
-                ref line,
-                ref line_number,
+                 error,
+                 line,
+                 line_number,
             } => write!(f, "Line error: {error} in line({line_number}): {line}"),
             SdpParserError::Unsupported {
-                ref error,
-                ref line,
-                ref line_number,
+                 error,
+                 line,
+                 line_number,
             } => write!(f, "Unsupported: {error} in line({line_number}): {line}",),
             SdpParserError::Sequence {
-                ref message,
-                ref line_number,
+                 message,
+                 line_number,
             } => write!(f, "Sequence error in line({line_number}): {message}"),
         }
     }
@@ -163,9 +163,9 @@ impl fmt::Display for SdpParserError {
 
 impl Error for SdpParserError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match *self {
-            SdpParserError::Line { ref error, .. }
-            | SdpParserError::Unsupported { ref error, .. } => Some(error),
+        match self {
+            SdpParserError::Line { error, .. }
+            | SdpParserError::Unsupported { error, .. } => Some(error),
             // Can't tell much more about our internal errors
             _ => None,
         }

--- a/src/error_tests.rs
+++ b/src/error_tests.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 fn test_sdp_parser_internal_error_unknown_address_type() {
     let error = SdpParserInternalError::UnknownAddressType("foo".to_string());
     assert_eq!(
-        format!("{}", error),
+        format!("{error}"),
         format!("{}: {}", INTERNAL_ERROR_MESSAGE_UNKNOWN_ADDRESS_TYPE, "foo")
     );
     assert!(error.source().is_none());
@@ -21,7 +21,7 @@ fn test_sdp_parser_internal_error_address_type_mismatch() {
         expected: AddressType::IpV6,
     };
     assert_eq!(
-        format!("{}", error),
+        format!("{error}"),
         format!(
             "{}: {}, {}",
             INTERNAL_ERROR_MESSAGE_ADDRESS_TYPE_MISMATCH,
@@ -35,7 +35,7 @@ fn test_sdp_parser_internal_error_address_type_mismatch() {
 #[test]
 fn test_sdp_parser_internal_error_generic() {
     let generic = SdpParserInternalError::Generic("generic message".to_string());
-    assert_eq!(format!("{}", generic), "Parsing error: generic message");
+    assert_eq!(format!("{generic}"), "Parsing error: generic message");
     assert!(generic.source().is_none());
 }
 
@@ -44,7 +44,7 @@ fn test_sdp_parser_internal_error_unsupported() {
     let unsupported =
         SdpParserInternalError::Unsupported("unsupported internal message".to_string());
     assert_eq!(
-        format!("{}", unsupported),
+        format!("{unsupported}"),
         "Unsupported parsing error: unsupported internal message"
     );
     assert!(unsupported.source().is_none());
@@ -57,10 +57,10 @@ fn test_sdp_parser_internal_error_integer() {
     assert!(integer.is_err());
     let int_err = SdpParserInternalError::Integer(integer.err().unwrap());
     assert_eq!(
-        format!("{}", int_err),
+        format!("{int_err}"),
         "Integer parsing error: invalid digit found in string"
     );
-    assert!(!int_err.source().is_none());
+    assert!(int_err.source().is_some());
 }
 
 #[test]
@@ -70,10 +70,10 @@ fn test_sdp_parser_internal_error_float() {
     assert!(float.is_err());
     let int_err = SdpParserInternalError::Float(float.err().unwrap());
     assert_eq!(
-        format!("{}", int_err),
+        format!("{int_err}"),
         "Float parsing error: invalid float literal"
     );
-    assert!(!int_err.source().is_none());
+    assert!(int_err.source().is_some());
 }
 
 #[test]
@@ -81,10 +81,10 @@ fn test_sdp_parser_internal_error_address() {
     let v = "127.0.0.500";
     let addr_err = Address::from_str(v).err().unwrap();
     assert_eq!(
-        format!("{}", addr_err),
+        format!("{addr_err}"),
         "Domain name parsing error: invalid IPv4 address"
     );
-    assert!(!addr_err.source().is_none());
+    assert!(addr_err.source().is_some());
 }
 
 #[test]
@@ -95,7 +95,7 @@ fn test_sdp_parser_error_line() {
         line_number: 13,
     };
     assert_eq!(
-        format!("{}", line1),
+        format!("{line1}"),
         "Line error: Parsing error: test message in line(13): test line"
     );
     assert!(line1.source().is_some());
@@ -109,7 +109,7 @@ fn test_sdp_parser_error_unsupported() {
         line_number: 21,
     };
     assert_eq!(
-        format!("{}", unsupported1),
+        format!("{unsupported1}"),
         "Unsupported: Parsing error: unsupported value in line(21): unsupported line"
     );
     assert!(unsupported1.source().is_some());
@@ -122,7 +122,7 @@ fn test_sdp_parser_error_sequence() {
         line_number: 42,
     };
     assert_eq!(
-        format!("{}", sequence1),
+        format!("{sequence1}"),
         "Sequence error in line(42): sequence message"
     );
     assert!(sequence1.source().is_none());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ impl fmt::Display for SdpBandwidth {
             SdpBandwidth::Tias(ref x) => ("TIAS", x),
             SdpBandwidth::Unknown(ref tp, ref x) => (&tp[..], x),
         };
-        write!(f, "{tp}:{val}", tp = tp_string, val = value)
+        write!(f, "{tp_string}:{value}")
     }
 }
 
@@ -292,8 +292,7 @@ impl SdpSession {
     pub fn add_attribute(&mut self, a: SdpAttribute) -> Result<(), SdpParserInternalError> {
         if !a.allowed_at_session_level() {
             return Err(SdpParserInternalError::Generic(format!(
-                "{} not allowed at session level",
-                a
+                "{a} not allowed at session level"
             )));
         };
         self.attribute.push(a);
@@ -312,7 +311,7 @@ impl SdpSession {
                     let _line_number = line.line_number;
                     self.add_attribute(a).map_err(|e: SdpParserInternalError| {
                         SdpParserError::Sequence {
-                            message: format!("{}", e),
+                            message: format!("{e}"),
                             line_number: _line_number,
                         }
                     })?
@@ -408,8 +407,7 @@ fn parse_version(value: &str) -> Result<SdpType, SdpParserInternalError> {
     let ver = value.parse::<u64>()?;
     if ver != 0 {
         return Err(SdpParserInternalError::Generic(format!(
-            "version type contains unsupported value {}",
-            ver
+            "version type contains unsupported value {ver}"
         )));
     };
     trace!("version: {}", ver);
@@ -493,7 +491,7 @@ fn parse_connection(value: &str) -> Result<SdpType, SdpParserInternalError> {
     let mut ttl = None;
     let mut amount = None;
     let mut addr_token = cv[2];
-    if addr_token.find('/') != None {
+    if addr_token.find('/').is_some() {
         let addr_tokens: Vec<&str> = addr_token.split('/').collect();
         if addr_tokens.len() >= 3 {
             amount = Some(addr_tokens[2].parse::<u32>()?);
@@ -544,7 +542,7 @@ fn parse_timing(value: &str) -> Result<SdpType, SdpParserInternalError> {
 }
 
 pub fn parse_sdp_line(line: &str, line_number: usize) -> Result<SdpLine, SdpParserError> {
-    if line.find('=') == None {
+    if line.find('=').is_none() {
         return Err(SdpParserError::Line {
             error: SdpParserInternalError::Generic("missing = character in line".to_string()),
             line: line.to_string(),
@@ -605,37 +603,30 @@ pub fn parse_sdp_line(line: &str, line_number: usize) -> Result<SdpLine, SdpPars
         "b" => parse_bandwidth(line_value),
         "c" => parse_connection(line_value),
         "e" => Err(SdpParserInternalError::Generic(format!(
-            "unsupported type email: {}",
-            line_value
+            "unsupported type email: {line_value}"
         ))),
         "i" => Err(SdpParserInternalError::Generic(format!(
-            "unsupported type information: {}",
-            line_value
+            "unsupported type information: {line_value}"
         ))),
         "k" => Err(SdpParserInternalError::Generic(format!(
-            "unsupported insecure key exchange: {}",
-            line_value
+            "unsupported insecure key exchange: {line_value}"
         ))),
         "m" => parse_media(line_value),
         "o" => parse_origin(line_value),
         "p" => Err(SdpParserInternalError::Generic(format!(
-            "unsupported type phone: {}",
-            line_value
+            "unsupported type phone: {line_value}"
         ))),
         "r" => Err(SdpParserInternalError::Generic(format!(
-            "unsupported type repeat: {}",
-            line_value
+            "unsupported type repeat: {line_value}"
         ))),
         "s" => parse_session(untrimmed_line_value),
         "t" => parse_timing(line_value),
         "u" => Err(SdpParserInternalError::Generic(format!(
-            "unsupported type uri: {}",
-            line_value
+            "unsupported type uri: {line_value}"
         ))),
         "v" => parse_version(line_value),
         "z" => Err(SdpParserInternalError::Generic(format!(
-            "unsupported type zone: {}",
-            line_value
+            "unsupported type zone: {line_value}"
         ))),
         _ => Err(SdpParserInternalError::Generic(
             "unknown sdp type".to_string(),
@@ -749,7 +740,7 @@ fn sanity_check_sdp_session(session: &SdpSession) -> Result<(), SdpParserError> 
             }
         }
 
-        if let Some(&SdpAttribute::Simulcast(ref simulcast)) =
+        if let Some(SdpAttribute::Simulcast(simulcast)) =
             msection.get_attribute(SdpAttributeType::Simulcast)
         {
             let check_defined_rids =

--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -196,8 +196,7 @@ impl SdpMedia {
     pub fn add_attribute(&mut self, attr: SdpAttribute) -> Result<(), SdpParserInternalError> {
         if !attr.allowed_at_media_level() {
             return Err(SdpParserInternalError::Generic(format!(
-                "{} not allowed at media level",
-                attr
+                "{attr} not allowed at media level"
             )));
         }
         self.attribute.push(attr);
@@ -318,8 +317,7 @@ fn parse_media_token(value: &str) -> Result<SdpMediaValue, SdpParserInternalErro
         "application" => SdpMediaValue::Application,
         _ => {
             return Err(SdpParserInternalError::Unsupported(format!(
-                "unsupported media value: {}",
-                value
+                "unsupported media value: {value}"
             )));
         }
     })
@@ -340,8 +338,7 @@ fn parse_protocol_token(value: &str) -> Result<SdpProtocolValue, SdpParserIntern
         "TCP/DTLS/SCTP" => SdpProtocolValue::TcpDtlsSctp,
         _ => {
             return Err(SdpParserInternalError::Unsupported(format!(
-                "unsupported protocol value: {}",
-                value
+                "unsupported protocol value: {value}"
             )));
         }
     })
@@ -459,7 +456,7 @@ pub fn parse_media_vector(lines: &mut Vec<SdpLine>) -> Result<Vec<SdpMedia>, Sdp
                     _ => sdp_media.add_attribute(a),
                 }
                 .map_err(|e: SdpParserInternalError| SdpParserError::Sequence {
-                    message: format!("{}", e),
+                    message: format!("{e}"),
                     line_number: _line_number,
                 })?
             }

--- a/src/network.rs
+++ b/src/network.rs
@@ -9,8 +9,8 @@ use std::str::FromStr;
 
 pub fn ip_address_to_string(addr: IpAddr) -> String {
     match addr {
-        IpAddr::V4(ipv4) => format!("IN IP4 {}", ipv4),
-        IpAddr::V6(ipv6) => format!("IN IP6 {}", ipv6),
+        IpAddr::V4(ipv4) => format!("IN IP4 {ipv4}"),
+        IpAddr::V6(ipv6) => format!("IN IP6 {ipv6}"),
     }
 }
 

--- a/tests/parse_sdp_tests.rs
+++ b/tests/parse_sdp_tests.rs
@@ -311,9 +311,9 @@ a=ssrc:2709871439 cname:{735484ea-4f6c-f74a-bd66-7425f8476c2e}";
     assert!(msection
         .get_attribute(webrtc_sdp::attribute_type::SdpAttributeType::Recvonly)
         .is_some());
-    assert!(!msection
+    assert!(msection
         .get_attribute(webrtc_sdp::attribute_type::SdpAttributeType::Extmap)
-        .is_some());
+        .is_none());
     assert_eq!(
         msection
             .get_attributes_of_type(webrtc_sdp::attribute_type::SdpAttributeType::Fmtp)
@@ -332,9 +332,9 @@ a=ssrc:2709871439 cname:{735484ea-4f6c-f74a-bd66-7425f8476c2e}";
     assert!(msection
         .get_attribute(webrtc_sdp::attribute_type::SdpAttributeType::Mid)
         .is_some());
-    assert!(!msection
+    assert!(msection
         .get_attribute(webrtc_sdp::attribute_type::SdpAttributeType::Msid)
-        .is_some());
+        .is_none());
     assert_eq!(
         msection
             .get_attributes_of_type(webrtc_sdp::attribute_type::SdpAttributeType::Rtcpfb)
@@ -402,9 +402,9 @@ fn parse_firefox_datachannel_offer() {
     assert!(msection
         .get_attribute(webrtc_sdp::attribute_type::SdpAttributeType::Sendrecv)
         .is_some());
-    assert!(!msection
+    assert!(msection
         .get_attribute(webrtc_sdp::attribute_type::SdpAttributeType::Extmap)
-        .is_some());
+        .is_none());
     assert!(msection
         .get_attribute(webrtc_sdp::attribute_type::SdpAttributeType::IcePwd)
         .is_some());
@@ -417,18 +417,18 @@ fn parse_firefox_datachannel_offer() {
     assert!(msection
         .get_attribute(webrtc_sdp::attribute_type::SdpAttributeType::Mid)
         .is_some());
-    assert!(!msection
+    assert!(msection
         .get_attribute(webrtc_sdp::attribute_type::SdpAttributeType::Msid)
-        .is_some());
-    assert!(!msection
+        .is_none());
+    assert!(msection
         .get_attribute(webrtc_sdp::attribute_type::SdpAttributeType::Rtcpfb)
-        .is_some());
-    assert!(!msection
+        .is_none());
+    assert!(msection
         .get_attribute(webrtc_sdp::attribute_type::SdpAttributeType::RtcpMux)
-        .is_some());
-    assert!(!msection
+        .is_none());
+    assert!(msection
         .get_attribute(webrtc_sdp::attribute_type::SdpAttributeType::Rtpmap)
-        .is_some());
+        .is_none());
     assert!(msection
         .get_attribute(webrtc_sdp::attribute_type::SdpAttributeType::Sctpmap)
         .is_some());


### PR DESCRIPTION
This fixes the `cargo clippy` warnings with version `clippy 0.1.69 (11d96b5 2023-02-01)`.