### PR TITLE
Relax format number restrictions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,6 @@ workflows:
           matrix:
             parameters:
               features: ["", "serialize"]
-              rustversion: ["1.58.0", "1.67"]
+              rustversion: ["1.60.0", "1.67"]
               latestrustversion: ["1.67"]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,6 @@ workflows:
           matrix:
             parameters:
               features: ["", "serialize"]
-              rustversion: ["1.60.0", "1.67"]
-              latestrustversion: ["1.67"]
+              rustversion: ["1.60.0", "1.70"]
+              latestrustversion: ["1.70"]
 

--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -377,15 +377,11 @@ pub fn parse_media(value: &str) -> Result<SdpType, SdpParserInternalError> {
             let mut fmt_vec: Vec<u32> = vec![];
             for num in fmt_slice {
                 let fmt_num = num.parse::<u32>()?;
-                match fmt_num {
-                    0  |  // PCMU
-                    8  |  // PCMA
-                    9  |  // G722
-                    13 |  // Comfort Noise
-                    35 ..= 63 | 96 ..= 127 => (),  // dynamic range
-                    _ => return Err(SdpParserInternalError::Generic(
-                          "format number in media line is out of range".to_string()))
-                };
+                if matches!(fmt_num, 1 | 2 | 19 | 64..=95 | 128 .. ) {
+                    return Err(SdpParserInternalError::Generic(
+                        "format number in media line is out of range".to_string(),
+                    ));
+                }
                 fmt_vec.push(fmt_num);
             }
             SdpFormatList::Integers(fmt_vec)


### PR DESCRIPTION
This relaxes the restrictions on format numbers to match [what is checked in Firefox](https://searchfox.org/mozilla-central/rev/961a9e56a0b5fa96ceef22c61c5e75fb6ba53395/dom/media/webrtc/jsep/JsepSessionImpl.cpp#46-51).