### PR TITLE
Bump minimum rust version to 1.70.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,6 @@ workflows:
           matrix:
             parameters:
               features: ["", "serialize"]
-              rustversion: ["1.60.0", "1.70"]
-              latestrustversion: ["1.70"]
+              rustversion: ["1.70.0", "1.81"]
+              latestrustversion: ["1.81"]
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A SDP parser written in Rust specifically aimed to handle WebRTC SDP offers and 
 
 ## Dependecies
 
-* Rust >= 1.60.0
+* Rust >= 1.70.0
 * log module
 * serde module
 * serde-derive module

--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -5,6 +5,7 @@
 extern crate url;
 use std::convert::TryFrom;
 use std::fmt;
+use std::fmt::Write;
 use std::iter;
 use std::str::FromStr;
 
@@ -218,11 +219,13 @@ impl fmt::Display for SdpAttributeCandidate {
             generation = option_to_string!(" generation {}", self.generation),
             ufrag = option_to_string!(" ufrag {}", self.ufrag),
             cost = option_to_string!(" network-cost {}", self.networkcost),
-            unknown = self
-                .unknown_extensions
-                .iter()
-                .map(|(name, value)| format!(" {name} {value}"))
-                .collect::<String>()
+            unknown =
+                self.unknown_extensions
+                    .iter()
+                    .fold(String::new(), |mut output, (name, value)| {
+                        let _ = write!(output, " {name} {value}");
+                        output
+                    })
         )
     }
 }


### PR DESCRIPTION
This bumps the minimum aversion of Rust supported to 1.70, and the maximum version to the latest release (1.81).