### PR TITLE
Fix invalid SDP generation

### DIFF
--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -46,6 +46,7 @@ macro_rules! maybe_vector_to_string {
                 $fmt_str,
                 $vec.iter()
                     .map(ToString::to_string)
+                    .filter(|s| !s.is_empty())
                     .collect::<Vec<String>>()
                     .join($sep)
             ),
@@ -716,11 +717,15 @@ pub struct SdpAttributeFmtp {
 
 impl fmt::Display for SdpAttributeFmtp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let parameters = self.parameters.to_string();
+        if parameters.is_empty() {
+            return Ok(());
+        }
         write!(
             f,
             "{pt} {parameter}",
             pt = self.payload_type,
-            parameter = self.parameters
+            parameter = parameters
         )
     }
 }
@@ -1508,7 +1513,13 @@ impl FromStr for SdpAttribute {
 impl fmt::Display for SdpAttribute {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let attr_type_name = SdpAttributeType::from(self).to_string();
-        let attr_to_string = |attr_str: String| attr_type_name + ":" + &attr_str;
+        let attr_to_string = |attr_str: String| {
+            if attr_str.is_empty() {
+                "".to_string()
+            } else {
+                attr_type_name + ":" + &attr_str
+            }
+        };
         match *self {
             SdpAttribute::BundleOnly => SdpAttributeType::BundleOnly.to_string(),
             SdpAttribute::Candidate(ref a) => attr_to_string(a.to_string()),

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -6,6 +6,7 @@ extern crate url;
 use super::*;
 use address::{Address, AddressType};
 use anonymizer::ToBytesVec;
+use attribute_type::{SdpAttributeFmtp, SdpAttributeFmtpParameters, SdpAttributeRtpmap};
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 
@@ -771,4 +772,65 @@ fn test_session_add_media_invalid_attribute_fails() -> Result<(), SdpParserInter
         )
         .is_err());
     Ok(())
+}
+
+#[test]
+fn test_default_fmtp_should_be_empty() -> Result<(), SdpParserError> {
+    let media_line = SdpMediaLine {
+        media: SdpMediaValue::Audio,
+        port: 9,
+        port_count: 0,
+        proto: SdpProtocolValue::RtpSavpf,
+        formats: SdpFormatList::Integers(Vec::new()),
+    };
+    let mut msection = SdpMedia::new(media_line);
+    msection
+        .add_codec(SdpAttributeRtpmap::new(96, "boofar".to_string(), 1001))
+        .unwrap();
+
+    assert!(msection
+        .add_attribute(SdpAttribute::Fmtp(SdpAttributeFmtp {
+            payload_type: 96,
+            parameters: SdpAttributeFmtpParameters {
+                packetization_mode: 0,
+                level_asymmetry_allowed: false,
+                profile_level_id: 0x0042_0010,
+                max_fs: 0,
+                max_cpb: 0,
+                max_dpb: 0,
+                max_br: 0,
+                max_mbps: 0,
+                usedtx: false,
+                stereo: false,
+                useinbandfec: false,
+                cbr: false,
+                max_fr: 0,
+                profile: None,
+                level_idx: None,
+                tier: None,
+                maxplaybackrate: 48000,
+                maxaveragebitrate: 0,
+                ptime: 0,
+                minptime: 0,
+                maxptime: 0,
+                encodings: Vec::new(),
+                dtmf_tones: "".to_string(),
+                rtx: None,
+                unknown_tokens: Vec::new()
+            }
+        }))
+        .is_ok());
+
+    let sdpstring = "v=0\r\n
+o=- 0 0 IN IP4 0.0.0.0\r\n
+s=-\r\n
+t=0 0\r\n"
+        .to_owned()
+        + &msection.to_string()
+        + "\r\nc=IN IP4 0.0.0.0";
+
+    assert!(msection.get_attribute(SdpAttributeType::Rtpmap).is_some());
+    assert!(msection.get_attribute(SdpAttributeType::Fmtp).is_some());
+
+    parse_sdp(&sdpstring, true).map(|_| ())
 }


### PR DESCRIPTION
When using all-default parameters for `SdpAttributeFmtp` the generated SDP string contains a line like `a=fmtp:96 ` which is invalid.

This PR fixes this by filtering out empty fmtp lines and also adds a corresponding test to the test suite.
The test uses `parse_sdp()` to check if the generated SDP is invalid or not.