### PR TITLE
Change default h264 profile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,5 @@ workflows:
           matrix:
             parameters:
               features: ["", "serialize"]
-              rustversion: ["1.85.0", "1.93.0"]
-              latestrustversion: ["1.93.0"]
-
+              rustversion: ["1.85.0", "1.97.1"]
+              latestrustversion: ["1.97.1"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,5 +88,5 @@ workflows:
           matrix:
             parameters:
               features: ["", "serialize"]
-              rustversion: ["1.85.0", "1.97.1"]
+              rustversion: ["1.88.0", "1.97.1"]
               latestrustversion: ["1.97.1"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 keywords = ["webrtc", "sdp", "jsep"]
 categories = ["parsing", "network-programming"]
 license = "MPL-2.0"
+rust-version = "1.88.0"
 
 [badges]
 travis-ci = { repository = "mozilla/webrtc-sdp", branch = "master" }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A SDP parser written in Rust specifically aimed to handle WebRTC SDP offers and 
 
 ## Dependecies
 
-* Rust >= 1.85.0
+* Rust >= 1.88.0
 * log module
 * serde module
 * serde-derive module

--- a/src/attribute_type.rs
+++ b/src/attribute_type.rs
@@ -665,7 +665,7 @@ impl fmt::Display for SdpAttributeFmtpParameters {
                 maybe_print_param(
                     "profile-level-id=",
                     format!("{:06x}", self.profile_level_id),
-                    "420010".to_string()
+                    "42000a".to_string()
                 ),
                 maybe_print_bool_param(
                     "level-asymmetry-allowed",
@@ -2120,7 +2120,7 @@ fn parse_fmtp(to_parse: &str) -> Result<SdpAttribute, SdpParserInternalError> {
     let mut parameters = SdpAttributeFmtpParameters {
         packetization_mode: 0,
         level_asymmetry_allowed: false,
-        profile_level_id: 0x0042_0010,
+        profile_level_id: 0x0042_000A,
         max_fs: 0,
         max_cpb: 0,
         max_dpb: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -896,7 +896,7 @@ pub fn parse_sdp(sdp: &str, fail_on_warning: bool) -> Result<SdpSession, SdpPars
     session.warnings = warnings;
 
     for warning in &session.warnings {
-        warn!("Warning: {}", &warning);
+        warn!("Warning: {}", warning);
     }
 
     Ok(session)


### PR DESCRIPTION
This replicates the changes from https://bugzilla.mozilla.org/show_bug.cgi?id=1901160.

Additionally I needed to update the minimum and maximum versions so that we can update the dependencies, and run all of our tooling. 
