### PR TITLE
Add pedantic feature for failures that are not always handled at parse time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,6 @@ workflows:
       - build:
           matrix:
             parameters:
-              features: ["", "serialize"]
+              features: ["", "serialize", "pedantic"]
               rustversion: ["1.88.0", "1.97.1"]
               latestrustversion: ["1.97.1"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ codecov = { repository = "mozilla/webrtc-sdp", branch = "master", service = "git
 default = ["enhanced_debug"]
 # debugging output
 enhanced_debug = []
+# pedantic checks
+pedantic = []
 # serializability
 serialize = ["serde", "serde_derive"]
 

--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -377,6 +377,7 @@ pub fn parse_media(value: &str) -> Result<SdpType, SdpParserInternalError> {
             let mut fmt_vec: Vec<u32> = vec![];
             for num in fmt_slice {
                 let fmt_num = num.parse::<u32>()?;
+                #[cfg(feature = "pedantic")]
                 if matches!(fmt_num, 1 | 2 | 19 | 64..=95 | 128 .. ) {
                     return Err(SdpParserInternalError::Generic(
                         "format number in media line is out of range".to_string(),

--- a/src/media_type_tests.rs
+++ b/src/media_type_tests.rs
@@ -307,6 +307,7 @@ fn test_media_invalid_transport() {
     assert!(parse_media("audio 9 invalid/invalid 8").is_err());
 }
 
+#[cfg(feature = "pedantic")]
 #[test]
 fn test_media_invalid_payload() {
     assert!(parse_media("audio 9 UDP/TLS/RTP/SAVPF 300").is_err());


### PR DESCRIPTION
This creates a pedantic errors feature which is not on by default. It moves the fmt range check into this category of failure.  