### PR TITLE
Allow for unknown media types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -737,6 +737,7 @@ fn sanity_check_sdp_session(session: &SdpSession) -> Result<(), SdpParserError> 
                         ));
                     }
                 }
+                SdpFormatList::Unknown(_) => {} // Unknown formats are unparsed
             }
         }
 

--- a/src/media_type.rs
+++ b/src/media_type.rs
@@ -30,12 +30,17 @@ impl fmt::Display for SdpMediaLine {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{media} {port}{pcount} {proto} {formats}",
+            "{media} {port}{pcount} {proto}{fmt_space}{formats}",
             media = self.media,
             port = self.port,
             pcount = maybe_print_param("/", self.port_count, 0),
             proto = self.proto,
-            formats = self.formats
+            // We need to avoid emitting a trailing space if an unknown media
+            // type is used and the format list is empty. We want to maintain
+            // string comparability between the parsed and reserialized media
+            // lines.
+            fmt_space = if self.formats.is_empty() { "" } else { " " },
+            formats = self.formats,
         )
     }
 }
@@ -46,6 +51,7 @@ pub enum SdpMediaValue {
     Audio,
     Video,
     Application,
+    Unknown(String),
 }
 
 impl fmt::Display for SdpMediaValue {
@@ -54,6 +60,7 @@ impl fmt::Display for SdpMediaValue {
             SdpMediaValue::Audio => "audio",
             SdpMediaValue::Video => "video",
             SdpMediaValue::Application => "application",
+            SdpMediaValue::Unknown(ref s) => s,
         }
         .fmt(f)
     }
@@ -100,15 +107,34 @@ impl fmt::Display for SdpProtocolValue {
 pub enum SdpFormatList {
     Integers(Vec<u32>),
     Strings(Vec<String>),
+    // Unknown media types have unknown format list types, and are not parsed
+    Unknown(String),
 }
 
 impl fmt::Display for SdpFormatList {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            SdpFormatList::Integers(ref x) => maybe_vector_to_string!("{}", x, " "),
-            SdpFormatList::Strings(ref x) => x.join(" "),
+            SdpFormatList::Integers(ref x) => write!(
+                f,
+                "{}",
+                x.iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<String>>()
+                    .join(" ")
+            ),
+            SdpFormatList::Strings(ref x) => write!(f, "{}", x.join(" ")),
+            SdpFormatList::Unknown(ref x) => write!(f, "{}", x),
         }
-        .fmt(f)
+    }
+}
+
+impl SdpFormatList {
+    pub fn is_empty(&self) -> bool {
+        match self {
+            SdpFormatList::Integers(x) => x.is_empty(),
+            SdpFormatList::Strings(x) => x.is_empty(),
+            SdpFormatList::Unknown(unparsed) => unparsed.is_empty(),
+        }
     }
 }
 
@@ -222,6 +248,7 @@ impl SdpMedia {
         match self.media.formats {
             SdpFormatList::Integers(_) => self.media.formats = SdpFormatList::Integers(Vec::new()),
             SdpFormatList::Strings(_) => self.media.formats = SdpFormatList::Strings(Vec::new()),
+            SdpFormatList::Unknown(_) => self.media.formats = SdpFormatList::Unknown(String::new()),
         }
 
         self.attribute.retain({
@@ -238,10 +265,12 @@ impl SdpMedia {
         });
     }
 
+    // This seems like it could be test-only
     pub fn add_codec(&mut self, rtpmap: SdpAttributeRtpmap) -> Result<(), SdpParserInternalError> {
         match self.media.formats {
             SdpFormatList::Integers(ref mut x) => x.push(u32::from(rtpmap.payload_type)),
             SdpFormatList::Strings(ref mut x) => x.push(rtpmap.payload_type.to_string()),
+            SdpFormatList::Unknown(_) => {}
         }
 
         self.add_attribute(SdpAttribute::Rtpmap(rtpmap))?;
@@ -315,11 +344,12 @@ fn parse_media_token(value: &str) -> Result<SdpMediaValue, SdpParserInternalErro
         "audio" => SdpMediaValue::Audio,
         "video" => SdpMediaValue::Video,
         "application" => SdpMediaValue::Application,
-        _ => {
-            return Err(SdpParserInternalError::Unsupported(format!(
-                "unsupported media value: {value}"
-            )));
+        "" => {
+            return Err(SdpParserInternalError::Generic(
+                "empty media value".to_string(),
+            ))
         }
+        _ => SdpMediaValue::Unknown(value.to_string()),
     })
 }
 
@@ -345,13 +375,37 @@ fn parse_protocol_token(value: &str) -> Result<SdpProtocolValue, SdpParserIntern
 }
 
 pub fn parse_media(value: &str) -> Result<SdpType, SdpParserInternalError> {
-    let mv: Vec<&str> = value.split_whitespace().collect();
-    if mv.len() < 4 {
+    // Split out the media type, port, and protocol tokens, with the remainder
+    // being the format list in single string.
+    let mv: Vec<&str> = value.splitn(4, char::is_whitespace).collect();
+    if mv.is_empty() {
         return Err(SdpParserInternalError::Generic(
-            "media attribute must have at least four tokens".to_string(),
+            "media attribute must have a media type".to_string(),
         ));
     }
     let media = parse_media_token(mv[0])?;
+    match (&media, mv.len()) {
+        (SdpMediaValue::Unknown(_), l) if l < 3 => {
+            // RFC 8866: https://www.rfc-editor.org/info/rfc8866/#MediaTypes
+            // While spec requires a <fmt> token, it leaves the definition of
+            // what is in that token to the specification that defines the
+            // media type. It could conceivably allow for an empty string.
+            // Since we ignore unknown media types, we refrain from having
+            // an opinion on the contents of <fmt>.
+            return Err(SdpParserInternalError::Generic(
+                "media attribute with unknown type must have at least 3 tokens".to_string(),
+            ));
+        }
+        (
+            m @ SdpMediaValue::Audio | m @ SdpMediaValue::Video | m @ SdpMediaValue::Application,
+            l,
+        ) if l < 4 => {
+            return Err(SdpParserInternalError::Generic(format!(
+                "media attribute of type {m} must have at least 4 tokens"
+            )));
+        }
+        _ => {}
+    }
     let mut ptokens = mv[1].split('/');
     let port = match ptokens.next() {
         None => {
@@ -371,9 +425,9 @@ pub fn parse_media(value: &str) -> Result<SdpType, SdpParserInternalError> {
         Some(c) => c.parse::<u32>()?,
     };
     let proto = parse_protocol_token(mv[2])?;
-    let fmt_slice: &[&str] = &mv[3..];
     let formats = match media {
         SdpMediaValue::Audio | SdpMediaValue::Video => {
+            let fmt_slice = &mv[3].split_whitespace().collect::<Vec<&str>>();
             let mut fmt_vec: Vec<u32> = vec![];
             for num in fmt_slice {
                 let fmt_num = num.parse::<u32>()?;
@@ -388,6 +442,7 @@ pub fn parse_media(value: &str) -> Result<SdpType, SdpParserInternalError> {
             SdpFormatList::Integers(fmt_vec)
         }
         SdpMediaValue::Application => {
+            let fmt_slice = &mv[3].split_whitespace().collect::<Vec<&str>>();
             let mut fmt_vec: Vec<String> = vec![];
             // TODO enforce length == 1 and content 'webrtc-datachannel' only?
             for token in fmt_slice {
@@ -395,6 +450,11 @@ pub fn parse_media(value: &str) -> Result<SdpType, SdpParserInternalError> {
             }
             SdpFormatList::Strings(fmt_vec)
         }
+        SdpMediaValue::Unknown(_) => SdpFormatList::Unknown(if mv.len() > 3 {
+            mv[3].to_string()
+        } else {
+            "".to_string()
+        }),
     };
     let m = SdpMediaLine {
         media,

--- a/src/media_type_tests.rs
+++ b/src/media_type_tests.rs
@@ -23,10 +23,11 @@ pub fn create_dummy_media_section() -> SdpMedia {
 
 // TODO is this useful outside of tests?
 impl SdpFormatList {
-    fn len(&self) -> usize {
+    fn len(&self) -> Option<usize> {
         match *self {
-            SdpFormatList::Integers(ref x) => x.len(),
-            SdpFormatList::Strings(ref x) => x.len(),
+            SdpFormatList::Integers(ref x) => Some(x.len()),
+            SdpFormatList::Strings(ref x) => Some(x.len()),
+            SdpFormatList::Unknown(_) => None,
         }
     }
 }
@@ -114,13 +115,13 @@ fn test_get_set_port() {
 fn test_add_codec() -> Result<(), SdpParserInternalError> {
     let mut msection = create_dummy_media_section();
     msection.add_codec(SdpAttributeRtpmap::new(96, "foobar".to_string(), 1000))?;
-    assert_eq!(msection.get_formats().len(), 1);
+    assert_eq!(msection.get_formats().len().unwrap(), 1);
     assert!(msection.get_attribute(SdpAttributeType::Rtpmap).is_some());
 
     let mut msection = create_dummy_media_section();
     msection.media.formats = SdpFormatList::Strings(Vec::new());
     msection.add_codec(SdpAttributeRtpmap::new(97, "boofar".to_string(), 1001))?;
-    assert_eq!(msection.get_formats().len(), 1);
+    assert_eq!(msection.get_formats().len().unwrap(), 1);
     assert!(msection.get_attribute(SdpAttributeType::Rtpmap).is_some());
     Ok(())
 }
@@ -129,21 +130,21 @@ fn test_add_codec() -> Result<(), SdpParserInternalError> {
 fn test_remove_codecs() -> Result<(), SdpParserInternalError> {
     let mut msection = create_dummy_media_section();
     msection.add_codec(SdpAttributeRtpmap::new(96, "foobar".to_string(), 1000))?;
-    assert_eq!(msection.get_formats().len(), 1);
+    assert_eq!(msection.get_formats().len().unwrap(), 1);
     assert!(msection.get_attribute(SdpAttributeType::Rtpmap).is_some());
     msection.remove_codecs();
-    assert_eq!(msection.get_formats().len(), 0);
+    assert_eq!(msection.get_formats().len().unwrap(), 0);
     assert!(msection.get_attribute(SdpAttributeType::Rtpmap).is_none());
 
     let mut msection = create_dummy_media_section();
     msection.media.formats = SdpFormatList::Strings(Vec::new());
     msection.add_codec(SdpAttributeRtpmap::new(97, "boofar".to_string(), 1001))?;
-    assert_eq!(msection.get_formats().len(), 1);
+    assert_eq!(msection.get_formats().len().unwrap(), 1);
 
     add_dummy_attributes(&mut msection);
 
     msection.remove_codecs();
-    assert_eq!(msection.get_formats().len(), 0);
+    assert_eq!(msection.get_formats().len().unwrap(), 0);
     assert!(msection.get_attribute(SdpAttributeType::Rtpmap).is_none());
     assert!(msection.get_attribute(SdpAttributeType::Rtcpfb).is_none());
     assert!(msection.get_attribute(SdpAttributeType::Fmtp).is_none());
@@ -222,9 +223,9 @@ fn test_parse_media_token() -> Result<(), SdpParserInternalError> {
     assert_eq!(video, SdpMediaValue::Video);
     let app = parse_media_token("aPplIcatIOn")?;
     assert_eq!(app, SdpMediaValue::Application);
-
     assert!(parse_media_token("").is_err());
-    assert!(parse_media_token("foobar").is_err());
+    let unknown = parse_media_token("foobar")?;
+    assert_eq!(unknown, SdpMediaValue::Unknown("foobar".to_string()));
     Ok(())
 }
 
@@ -293,8 +294,41 @@ fn test_media_invalid_port_number() {
 }
 
 #[test]
-fn test_media_invalid_type() {
-    assert!(parse_media("invalid 9 UDP/TLS/RTP/SAVPF 8").is_err());
+fn test_media_unknown_type() {
+    check_parse_and_serialize("unknownFormat 9 UDP/TLS/RTP/SAVPF");
+    let media = parse_media("unknownFormat 9 UDP/TLS/RTP/SAVPF")
+        .expect("Unknown media type should be parsed");
+    assert!(matches!(media, SdpType::Media(_)));
+    if let SdpType::Media(media) = media {
+        let expected = SdpMediaValue::Unknown("unknownFormat".to_string());
+        assert_eq!(media.media, expected);
+        assert_eq!(media.port, 9);
+        assert_eq!(media.port_count, 0);
+        assert_eq!(media.proto, SdpProtocolValue::UdpTlsRtpSavpf);
+        assert!(matches!(media.formats, SdpFormatList::Unknown(_)));
+        if let SdpFormatList::Unknown(formats) = media.formats {
+            assert_eq!(formats, "".to_string());
+        }
+    }
+}
+
+#[test]
+fn test_media_unknown_type_with_fmt() {
+    check_parse_and_serialize("unknownFormat 9 UDP/TLS/RTP/SAVPF 8A J");
+    let media = parse_media("unknownFormat 9 UDP/TLS/RTP/SAVPF 8A J")
+        .expect("Unknown media type should be parsed");
+    assert!(matches!(media, SdpType::Media(_)));
+    if let SdpType::Media(media) = media {
+        let expected = SdpMediaValue::Unknown("unknownFormat".to_string());
+        assert_eq!(media.media, expected);
+        assert_eq!(media.port, 9);
+        assert_eq!(media.port_count, 0);
+        assert_eq!(media.proto, SdpProtocolValue::UdpTlsRtpSavpf);
+        assert!(matches!(media.formats, SdpFormatList::Unknown(_)));
+        if let SdpFormatList::Unknown(formats) = media.formats {
+            assert_eq!(formats, "8A J".to_string());
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
We should be ignoring unknown media types instead of rejecting them. Each media type defines its own \<fmt\> grammar. Reserialization requires that we preserve the \<fmt\> section of the m= line even though we do not know how to parse it. The solution I have chosen is to not make assumptions about how it should be tokenized (or if it can be empty). It is instead stored as a string.

For motivation see: https://bugzilla.mozilla.org/show_bug.cgi?id=1806185